### PR TITLE
refactor: improve conversion form component

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -117,7 +117,6 @@ const config = {
             label: "Home",
             position: "left",
           },
-          { to: "/#about", label: "About", position: "left" },
           {
             type: "dropdown",
             to: "/#solutions",

--- a/src/components/HomeConversionForm.tsx
+++ b/src/components/HomeConversionForm.tsx
@@ -1,13 +1,18 @@
 import React from "react";
 
-import ButtonGhost from "./buttons/ButtonGhost";
 import ButtonPrimary from "./buttons/ButtonPrimary";
 import ButtonPrimaryInverted from "./buttons/ButtonPrimaryInverted";
+import clsx from "clsx";
 
-const HomeConversionForm = () => {
+const HomeConversionForm = ({ className }: { className?: string }) => {
   return (
-    <div className="bg-gradient-to-b from-transparent to-primary-wopee dark:to-secondary-wopee mt-16 ">
-      <div className="container mt-16 h-[50vh] flex flex-col justify-center gap-10">
+    <div
+      className={clsx(
+        "bg-gradient-to-b from-transparent to-primary-wopee dark:to-secondary-wopee mt-16",
+        className
+      )}
+    >
+      <div className="container my-16 h-[50vh] flex flex-col justify-center gap-10">
         <h2 className="text-4xl font-bold text-secondary-wopee dark:text-primary-wopee">
           Immerse yourself in the autonomous testing experience with Wopee.io
         </h2>

--- a/src/components/HomeSolutions.tsx
+++ b/src/components/HomeSolutions.tsx
@@ -3,6 +3,23 @@ import React from "react";
 import Link from "@docusaurus/Link";
 import ButtonGhost from "./buttons/ButtonGhost";
 
+const LinkIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className="w-6 h-6"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"
+    />
+  </svg>
+);
+
 export default function HomepageHowItWorks(): JSX.Element {
   return (
     <section
@@ -20,7 +37,11 @@ export default function HomepageHowItWorks(): JSX.Element {
         <div className="card flex flex-1 p-5 md:p-10 justify-between gap-5 drop-shadow-lg overflow-visible">
           <div className="flex flex-col gap-5">
             <h3 className="text-lg md:text-xl xl:text-2xl font-bold text-secondary-wopee dark:text-primary-wopee">
-              <Link to="/wopee-copilot">Testing Copilot</Link>
+              <Link to="/wopee-copilot">
+                <span className="flex items-center justify-center gap-1">
+                  Visual Testing Copilot <LinkIcon />
+                </span>
+              </Link>
             </h3>
             <p className="text-sm md:text-lg xl:text-xl">
               Use your existing automated tests and boost its efficiency.
@@ -29,7 +50,12 @@ export default function HomepageHowItWorks(): JSX.Element {
               We have simple plug &amp; play solutions ready for your existing
               Selenium, Playwright, Cypress.io and Robot Framework testing
               projects. If you use some other tools, we are also ready to build
-              special assistants just for you! ❤️
+              special assistants just for you! ❤️{" "}
+              <Link to="/wopee-copilot">
+                <small className="opacity-95 inline-flex items-center">
+                  Read more..
+                </small>
+              </Link>
             </p>
           </div>
           <Link
@@ -43,7 +69,11 @@ export default function HomepageHowItWorks(): JSX.Element {
         <div className="card flex flex-1 p-5 md:p-10 justify-between gap-5 drop-shadow-lg overflow-visible">
           <div className="flex flex-col gap-5">
             <h3 className="text-lg md:text-xl xl:text-2xl font-bold text-secondary-wopee dark:text-primary-wopee">
-              <Link to="/wopee-bot">Self-driving Bot</Link>
+              <Link to="/wopee-bot">
+                <span className="flex items-center justify-center gap-1">
+                  Autonomous Testing Bot <LinkIcon />
+                </span>
+              </Link>
             </h3>
             <p className="text-sm md:text-lg xl:text-xl">
               Independent testing bot, no automation required.
@@ -52,7 +82,12 @@ export default function HomepageHowItWorks(): JSX.Element {
               Our bots explore your Web App, learn how it works and it is ready
               for testing. Sometimes it is not human to ask humans to test
               (running regression testing ... especially several times a
-              week/day, running it on many configurations, etc.)
+              week/day, running it on many configurations, etc.){" "}
+              <Link to="/wopee-bot">
+                <small className="opacity-95 inline-flex items-center">
+                  Read more..
+                </small>
+              </Link>
             </p>
           </div>
           <Link

--- a/src/pages/wopee-bot/index.tsx
+++ b/src/pages/wopee-bot/index.tsx
@@ -3,6 +3,7 @@ import { useWindowSize } from "usehooks-ts";
 
 import Layout from "@theme/Layout";
 import Modal from "@site/src/components/dialog/Modal";
+import HomeConversionForm from "@site/src/components/HomeConversionForm";
 
 const WopeeBotPage = () => {
   const [open, setOpen] = useState(false);
@@ -234,6 +235,7 @@ const WopeeBotPage = () => {
           chosenImageSrc={chosenImageSrc}
         />
       </main>
+      <HomeConversionForm className="-mt-20" />
     </Layout>
   );
 };

--- a/src/pages/wopee-commander/index.tsx
+++ b/src/pages/wopee-commander/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useRef, useState } from "react";
 import Layout from "@theme/Layout";
 import Link from "@docusaurus/Link";
 import Modal from "@site/src/components/dialog/Modal";
+import HomeConversionForm from "@site/src/components/HomeConversionForm";
 
 const WopeeCommanderPage = () => {
   const [open, setOpen] = useState(false);
@@ -195,6 +196,7 @@ const WopeeCommanderPage = () => {
           chosenImageSrc={chosenImageSrc}
         />
       </main>
+      <HomeConversionForm className="-mt-20" />
     </Layout>
   );
 };

--- a/src/pages/wopee-copilot/index.tsx
+++ b/src/pages/wopee-copilot/index.tsx
@@ -3,6 +3,7 @@ import { useWindowSize } from "usehooks-ts";
 
 import Layout from "@theme/Layout";
 import Modal from "@site/src/components/dialog/Modal";
+import HomeConversionForm from "@site/src/components/HomeConversionForm";
 
 const supportedTestingTools = [
   {
@@ -210,6 +211,7 @@ const WopeeCopilotPage = () => {
           chosenImageSrc={chosenImageSrc}
         />
       </main>
+      <HomeConversionForm className="-mt-20" />
     </Layout>
   );
 };


### PR DESCRIPTION
re-use conversion from component in new pages that lack cta adjust card titles to match corresponding pages
add visual indications for links on titles
add additional cta to follow corresponding page if interested remove mundane about section from nav