### PR TITLE
refactor: remove hover effects on plan cards

### DIFF
--- a/src/components/HomeAbout.tsx
+++ b/src/components/HomeAbout.tsx
@@ -9,13 +9,13 @@ export default function HomepageAbout(): JSX.Element {
   return (
     <section
       id="about"
-      className="mt-5 md:mt-10 overflow-visible"
+      className="mt-5 md:mt-10"
     >
       <h2 className="text-xl text-center md:text-center md:text-2xl xl:text-5xl font-bold text-secondary-wopee dark:text-primary-wopee mb-3">
         What's the problem?
       </h2>
 
-      <div className="card flex flex-col lg:flex-row drop-shadow-xl">
+      <div className="card flex flex-col lg:flex-row shadow-xl">
         <div className="flex-1 p-5 md:p-10">
           <img
             src={aboutImg}

--- a/src/components/HomeCustomers.tsx
+++ b/src/components/HomeCustomers.tsx
@@ -9,7 +9,7 @@ export default function HomepageHowItWorks(): JSX.Element {
   return (
     <section
       id="customers"
-      className="mt-16 md:mt-20 text-center overflow-visible"
+      className="mt-16 md:mt-20 text-center"
     >
       <h2 className="text-xl md:text-2xl xl:text-5xl font-bold text-secondary-wopee dark:text-primary-wopee">
         Join our early adopters
@@ -18,8 +18,8 @@ export default function HomepageHowItWorks(): JSX.Element {
         Trusted by the technology leaders, our early customers
       </p>
 
-      <div className="flex flex-col mt-3 md:mt-5 gap-y-5 gap-x-5 items-center sm:flex-row overflow-visible">
-        <div className="card flex md:h-[500px] xl:h-[450px] flex-col justify-center sm:w-1/2 p-10 gap-2 xl:gap-5 drop-shadow-xl overflow-visible">
+      <div className="flex flex-col mt-3 md:mt-5 gap-y-5 gap-x-5 items-center sm:flex-row">
+        <div className="card flex md:h-[500px] xl:h-[450px] flex-col justify-center sm:w-1/2 p-10 gap-2 xl:gap-5 shadow-xl">
           <div className="">
             <img
               src={multitudeImg}
@@ -55,7 +55,7 @@ export default function HomepageHowItWorks(): JSX.Element {
           </div>
         </div>
 
-        <div className="card flex md:h-[500px] xl:h-[450px] flex-col justify-center sm:w-1/2 p-10 gap-2 xl:gap-5 drop-shadow-xl overflow-visible">
+        <div className="card flex md:h-[500px] xl:h-[450px] flex-col justify-center sm:w-1/2 p-10 gap-2 xl:gap-5 shadow-xl">
           <div className="">
             <img
               src={livesportImg}

--- a/src/components/HomeSolutions.tsx
+++ b/src/components/HomeSolutions.tsx
@@ -24,7 +24,7 @@ export default function HomepageHowItWorks(): JSX.Element {
   return (
     <section
       id="solutions"
-      className="mt-16 md:mt-20 text-center overflow-visible"
+      className="mt-16 md:mt-20 text-center"
     >
       <h2 className="text-xl text-center md:text-center md:text-2xl xl:text-5xl font-bold text-secondary-wopee dark:text-primary-wopee">
         Solutions
@@ -33,8 +33,8 @@ export default function HomepageHowItWorks(): JSX.Element {
         Wopee.io increases your efficiency and removes testing waste.
       </p>
 
-      <div className="flex flex-col sm:flex-row gap-5 mt-3 md:mt-5 overflow-visible">
-        <div className="card flex flex-1 p-5 md:p-10 justify-between gap-5 drop-shadow-lg overflow-visible">
+      <div className="flex flex-col sm:flex-row gap-5 mt-3 md:mt-5">
+        <div className="card flex flex-1 p-5 md:p-10 justify-between gap-5 shadow-lg">
           <div className="flex flex-col gap-5">
             <h3 className="text-lg md:text-xl xl:text-2xl font-bold text-secondary-wopee dark:text-primary-wopee">
               <Link to="/wopee-copilot">
@@ -66,7 +66,7 @@ export default function HomepageHowItWorks(): JSX.Element {
           </Link>
         </div>
 
-        <div className="card flex flex-1 p-5 md:p-10 justify-between gap-5 drop-shadow-lg overflow-visible">
+        <div className="card flex flex-1 p-5 md:p-10 justify-between gap-5 shadow-lg">
           <div className="flex flex-col gap-5">
             <h3 className="text-lg md:text-xl xl:text-2xl font-bold text-secondary-wopee dark:text-primary-wopee">
               <Link to="/wopee-bot">

--- a/src/components/pricing/PlanItem.tsx
+++ b/src/components/pricing/PlanItem.tsx
@@ -1,3 +1,4 @@
+import clsx from "clsx";
 import React from "react";
 
 type PlanItem = {
@@ -33,7 +34,7 @@ export const PlanItems: PlanItem[] = [
       "3 dedicated bots",
       "30 days data retention",
     ],
-    featured: false,
+    featured: true,
   },
   {
     title: "Ultimate",
@@ -59,7 +60,12 @@ export default function PlanItem({
   featured,
 }: PlanItem) {
   return (
-    <div className="card flex flex-col items-center justify-center gap-5 p-5 drop-shadow-xl sm:hover:scale-105 transition duration-300 overflow-visible">
+    <div
+      className={clsx(
+        "card flex flex-col items-center justify-center gap-5 p-5 shadow-xl",
+        featured ? "scale-105" : ""
+      )}
+    >
       <img
         src={img}
         alt="Image alt text"

--- a/src/components/pricing/Pricing.tsx
+++ b/src/components/pricing/Pricing.tsx
@@ -19,12 +19,12 @@ export const freePlanCardItems = {
 
 export default function Pricing(): JSX.Element {
   return (
-    <main className="my-16 text-center overflow-visible">
+    <main className="my-16 text-center">
       <h2 className="text-3xl text-center md:text-center xl:text-5xl font-bold text-secondary-wopee dark:text-primary-wopee">
         Pricing
       </h2>
 
-      <div className="flex flex-col sm:flex-wrap items-center sm:flex-row xl:flex-nowrap mt-10 md:mt-10 justify-center gap-5 sm:gap-7 overflow-visible">
+      <div className="flex flex-col sm:flex-wrap items-center sm:flex-row xl:flex-nowrap mt-10 md:mt-10 justify-center gap-5 sm:gap-7">
         {PlanItems.map((props, idx) => (
           <PlanItem
             key={idx}
@@ -40,7 +40,7 @@ export default function Pricing(): JSX.Element {
       </div>
 
       <div className="my-10 flex flex-col gap-3 items-center">
-        <div className="card flex sm:flex-row max-w-5xl sm:min-w-[800px] items-center sm:justify-between gap-5 p-10 drop-shadow-xl sm:hover:scale-105 transition duration-300">
+        <div className="card flex sm:flex-row max-w-5xl sm:min-w-[800px] items-center sm:justify-between gap-5 p-10 shadow-xl">
           <figure className="text-7xl m-0 w-1/3">🚀</figure>
 
           <div className="sm:w-1/3">
@@ -60,7 +60,7 @@ export default function Pricing(): JSX.Element {
           </Link>
         </div>
 
-        <div className="card flex sm:flex-row max-w-5xl sm:min-w-[800px] items-center sm:justify-between gap-5 p-10 drop-shadow-xl sm:hover:scale-105 transition duration-300">
+        <div className="card flex sm:flex-row max-w-5xl sm:min-w-[800px] items-center sm:justify-between gap-5 p-10 shadow-xl">
           <div className="w-[200px] sm:w-1/3">
             <img
               src={freePlanCardItems.img}

--- a/src/components/team/Team.tsx
+++ b/src/components/team/Team.tsx
@@ -5,7 +5,7 @@ import { TeamMemberCard } from "./TeamMemberCard";
 
 export default function Team(): JSX.Element {
   return (
-    <section className="mt-8 mb-16 text-center overflow-visible">
+    <section className="mt-8 mb-16 text-center">
       <h2 className="text-xl text-center md:text-center md:text-2xl xl:text-5xl font-bold text-secondary-wopee dark:text-primary-wopee">
         Wopees
       </h2>

--- a/src/components/team/TeamMemberCard.tsx
+++ b/src/components/team/TeamMemberCard.tsx
@@ -9,7 +9,7 @@ export function TeamMemberCard({
   linkedIn,
 }: TeamMember) {
   return (
-    <div className="max-w-[328px] flex flex-col rounded-lg drop-shadow-lg overflow-visible">
+    <div className="max-w-[328px] flex flex-col rounded-lg shadow-lg">
       <img
         className="rounded-t-lg object-cover h-[328px]"
         src={img}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -50,7 +50,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout>
       <HomeHeader />
-      <main className="container overflow-visible">
+      <main className="container">
         <HomeAbout />
         <HomeSolutions />
         <HomeHowItWorks />

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -6,7 +6,7 @@ import Pricing from "@site/src/components/pricing/Pricing";
 const PricingPage = () => {
   return (
     <Layout>
-      <main className="container overflow-visible">
+      <main className="container">
         <Pricing />
       </main>
     </Layout>


### PR DESCRIPTION
refactor: keep premium plan card zoomed at all times
refactor: substitute drop shadow with regular shadow - bad support across browsers