### PR TITLE
fix: add SEO metadata, Organization JSON-LD, and subtle CTA to about-us

### DIFF
--- a/src/pages/about-us/index.tsx
+++ b/src/pages/about-us/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 
+import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
 import PartnersCarouselCard from "@site/src/components/demo/PartnersCarouselCard";
 
@@ -16,9 +17,38 @@ const INVESTORS = [
   },
 ];
 
+const JSONLD_ORG = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Wopee.io",
+  legalName: "wopee labs s.r.o.",
+  url: "https://wopee.io",
+  logo: "https://wopee.io/img/logo.png",
+  email: "help@wopee.io",
+  address: {
+    "@type": "PostalAddress",
+    streetAddress: "Pujmanove 883/23",
+    addressLocality: "Prague",
+    postalCode: "140 00",
+    addressCountry: "CZ",
+  },
+  sameAs: [
+    "https://www.linkedin.com/company/wopee",
+    "https://github.com/Wopee-io",
+    "https://www.youtube.com/@wopee",
+  ],
+};
+
 const TeamPage = () => {
   return (
-    <Layout title="About Us">
+    <Layout title="About Wopee.io | AI Testing Agents for Web Apps">
+      <Head>
+        <meta
+          name="description"
+          content="Learn about Wopee.io — autonomous AI testing agents for web apps. Contact wopee labs s.r.o. for support, product questions, and collaboration."
+        />
+        <script type="application/ld+json">{JSON.stringify(JSONLD_ORG)}</script>
+      </Head>
       <main>
         {/* Hero */}
         <section className="py-20 px-4 text-center">
@@ -107,6 +137,18 @@ const TeamPage = () => {
               <p>Reg. No.: 17997224 | VAT: CZ17997224</p>
             </div>
           </div>
+        </section>
+
+        {/* CTA */}
+        <section className="pb-16 px-4 text-center">
+          <a
+            href="https://cmd.wopee.io"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block px-6 py-3 text-sm font-medium rounded-lg border border-solid border-gray-600 opacity-80 hover:opacity-100 transition-opacity"
+          >
+            Start free trial
+          </a>
         </section>
       </main>
     </Layout>


### PR DESCRIPTION
## Summary

Small polish follow-up to PR #137:

- **SEO metadata**: page title "About Wopee.io | AI Testing Agents for Web Apps" + meta description
- **Organization JSON-LD**: schema.org structured data with legal name, address, email, logo, social profiles
- **Subtle CTA**: single "Start free trial" button at bottom

No layout or content changes to the page itself.

## Test plan

- [x] `yarn build` passes
- [x] View page source — verify JSON-LD and meta tags present