### PR TITLE
feat(seo): add meta descriptions, AIO openers to homepage and blog posts

### DIFF
--- a/blog/2024-07-23-self-healing-in-sw-test-automation/index.md
+++ b/blog/2024-07-23-self-healing-in-sw-test-automation/index.md
@@ -1,14 +1,13 @@
 ---
 slug: self-healing-in-sw-test-automation
-title: Self-healing in SW Test Automation Explained
+title: "Self-Healing Test Automation: Fix Broken Tests Automatically"
+description: "What is self-healing in test automation? Tests that detect UI changes and repair their own selectors in real time. Complete guide with examples and tools."
 authors: marcel
 tags: [automation, self-healing, ai, machine-learning, ci-cd, reliability]
 image: ./self-healing-explained.jpg
 ---
 
-Self-Healing in Test Automation: The Future of Reliable Testing?
-
-Maintaining robust test automation can be a daunting challenge. As applications evolve rapidly, test scripts often break due to changes in the user interface (UI) or application structure. This leads to increased maintenance overhead, false test failures, and reduced confidence in the test suite.
+What is self-healing in test automation? It is a mechanism where tests automatically repair broken locators when the application UI changes. When a selector fails, the self-healing engine analyzes the DOM, identifies the intended element using alternative attributes, and updates the test in real time — turning brittle test suites into resilient ones without manual intervention.
 
 <!--truncate-->
 

--- a/blog/2024-08-02-BDD-w-Robot-Framework/index.md
+++ b/blog/2024-08-02-BDD-w-Robot-Framework/index.md
@@ -1,12 +1,13 @@
 ---
 slug: bdd-with-robot-framework
-title: Getting Started with BDD in Robot Framework
+title: "BDD with Robot Framework: A Practical Guide with Examples"
+description: "Learn how to implement BDD in Robot Framework with Gherkin syntax, Example Mapping, and real automation examples. From user stories to executable test cases."
 authors: marcel
 tags: [bdd, robot-framework, example-mapping, gherkin, automation, testing]
 image: ./bdd-process.png
 ---
 
-Behavior-driven development (BDD) is an effective method for software teams to collaborate. By fostering communication between business and technical personnel, BDD ensures a shared understanding of the problems at hand and promotes the rapid, iterative development of solutions. This article will guide you through the essentials of BDD and demonstrate how to implement it using Robot Framework.
+What is BDD in Robot Framework? It is a testing approach where teams write test cases using Given-When-Then syntax that Robot Framework executes directly as automated tests. BDD bridges the gap between business requirements and test automation by making test scenarios readable by non-technical stakeholders while remaining fully executable. Robot Framework supports this through built-in Gherkin keywords and its keyword-driven architecture.
 
 <!--truncate-->
 

--- a/blog/2024-08-12-predictive-test-selection/index.md
+++ b/blog/2024-08-12-predictive-test-selection/index.md
@@ -1,6 +1,7 @@
 ---
 slug: predictive-test-selection
-title: Predictive Test Selection in Test Automation Explained
+title: "Predictive Test Selection: Run Only the Tests That Matter"
+description: "What is predictive test selection? An AI-driven approach that analyzes code changes and runs only the tests most likely to fail — cutting CI time without losing coverage."
 authors: marcel
 tags:
   [
@@ -12,7 +13,7 @@ tags:
 image: ./test-selection.jpg
 ---
 
-The need to release high-quality products quickly is more critical than ever. While test automation has greatly improved the efficiency of testing processes, the sheer volume of tests required can still overwhelm even the most streamlined teams. Enter **Predictive Test Selection (PTS)**—an AI-driven approach designed to optimize and accelerate the testing process by focusing on the areas of your code most likely to fail. In this article, we’ll explore how PTS enhances test automation, ensuring earlier defect detection, reduced testing time, and improved software quality.
+Predictive test selection uses machine learning to decide which tests to run for each code change. It works by analyzing commit history, code coverage data, and past failure patterns to rank tests by risk. High-risk tests run first, low-risk tests are deferred or skipped — giving teams faster CI feedback while maintaining defect coverage across releases.
 
 <!--truncate-->
 
@@ -28,7 +29,6 @@ The process of selecting which tests to run has evolved significantly over time.
 ### Manual Prioritization: The Early Days
 
 - **Experience-Based Decision Making**: In the early stages of software testing, test leads and QA teams relied heavily on their experience and intuition to prioritize tests. This often involved:
-
   - **Gut Instincts and Expertise**: Testers would choose which tests to run based on their knowledge of the codebase and past experiences with similar issues.
   - **Ad Hoc Processes**: There was little to no formal structure, with decisions made on the fly depending on the perceived risk or importance of certain features.
 
@@ -39,7 +39,6 @@ The process of selecting which tests to run has evolved significantly over time.
 ### Tagging and Grouping Test Cases: Structuring the Process
 
 - **Introduction of Tags**: To bring more structure to test selection, teams began using tags to group test cases. This approach involved:
-
   - **Categorizing Tests**: Test cases were labeled based on various attributes, such as functionality, risk level, or the module they covered.
   - **Easier Selection**: Tags allowed teams to quickly filter and select relevant tests, particularly for regression testing, where running the entire test suite might be impractical.
 
@@ -52,12 +51,10 @@ The process of selecting which tests to run has evolved significantly over time.
 The next step in the evolution was to enhance previous Tagging and Grouping Test Cases methods. Teams have started adopting more analytical approaches to test prioritization, such as Risk-Based Testing and Coverage-Based Testing.
 
 - **Risk-Based Testing**: This method prioritized tests based on the potential impact of a failure. It involved:
-
   - **Identifying High-Risk Areas**: Tests were focused on the most critical parts of the application, where defects would have the most significant consequences.
   - **Optimizing Resource Allocation**: Resources were directed towards testing areas with the highest risk, ensuring that critical issues were caught early.
 
 - **Coverage-Based Testing**: Another strategy was to prioritize tests based on code coverage metrics:
-
   - **Maximizing Coverage**: Tests were selected to cover the most lines of code or the most critical paths through the codebase.
   - **Balancing Quality and Efficiency**: This approach sought to balance thoroughness with the need to run tests efficiently, though it still required manual input and analysis.
 
@@ -68,13 +65,11 @@ The next step in the evolution was to enhance previous Tagging and Grouping Test
 ### AI-Driven Predictions: The Modern Approach
 
 - **Harnessing Machine Learning**: With the advent of AI and machine learning, Predictive Test Selection offers a leap forward in how tests are prioritized:
-
   - **Data-Driven Insights**: PTS leverages historical test results, code changes, bug reports, and other relevant factors to predict which tests are most likely to uncover defects.
   - **Dynamic Prioritization**: Unlike static tagging or manual prioritization, PTS dynamically adapts to the latest code changes, ensuring that the most critical tests are run first.
   - **Continuous Learning**: The AI models continuously learn from each testing cycle, improving their accuracy and relevance over time.
 
 - **Key Advantages**:
-
   - **Consistency and Accuracy**: By removing the subjectivity involved in manual prioritization, PTS provides consistent and accurate test selection.
   - **Scalability**: AI-driven test selection easily scales with the complexity and size of the project, making it suitable for large, evolving codebases.
   - **Efficiency Gains**: By focusing on the areas of the code most likely to fail, PTS reduces the need to run unnecessary tests, saving time and resources.
@@ -109,22 +104,18 @@ Implementing Predictive Test Selection offers numerous advantages:
 While Predictive Test Selection (PTS) offers significant benefits, it also presents certain challenges that teams must address to fully realize its potential. However, many of these challenges can be minimized or even fully eliminated with the proper selection of tools and strategies. Understanding and mitigating these challenges is key to successful implementation. Here are the main hurdles and tips how to overcome them:
 
 - **Data Quality and Availability:**
-
   - **Challenge:** The effectiveness of PTS relies heavily on the quality and quantity of historical data. If the data used to train predictive models is incomplete, outdated, or inaccurate, the predictions will be unreliable.
   - **Solution:** Ensure that your data collection processes are robust and comprehensive. Regularly update and clean your data sets to maintain their relevance. Consider incorporating multiple sources of data, such as logs, user feedback, and code commit histories, to enrich the model’s accuracy.
 
 - **Integration Complexity:**
-
   - **Challenge:** Integrating PTS into existing workflows, particularly in established CI/CD pipelines, can be complex and may require significant changes to your infrastructure.
   - **Solution:** Start with a phased implementation. Begin by integrating PTS in non-critical areas or parallel to your current processes to minimize disruption. Gradually expand its use as your team becomes more comfortable with the technology. Additionally, choose tools that offer strong support and documentation to ease the integration process.
 
 - **Model Training and Maintenance:**
-
   - **Challenge:** Predictive models need continuous training and refinement to remain effective. This requires ongoing maintenance, which can be resource-intensive.
   - **Solution:** Automate the retraining of models as much as possible. Set up regular intervals for model evaluation and retraining based on new data. Leverage AI tools that offer automated model updates to reduce the manual workload on your team.
 
 - **Stakeholder Buy-In:**
-
   - **Challenge:** Gaining buy-in from both technical and non-technical stakeholders can be difficult, especially if they are unfamiliar with AI-driven approaches.
   - **Solution:** Clearly communicate the benefits of PTS, such as faster testing cycles and improved software quality, to all stakeholders. Use case studies and pilot projects to demonstrate its value in a real-world context. Encourage a culture of experimentation and innovation, allowing team members to explore and understand the technology.
 
@@ -174,17 +165,14 @@ If you're interested in exploring the tools mentioned in this article, here are 
 Intelligent test execution is not just about deciding which tests to run; it’s also about determining the optimal timing and context for executing those tests. This dynamic decision-making process allows teams to adapt their testing strategies based on various factors such as the state of the code, the development environment, and the goals of the testing phase. Let’s explore various approaches to test execution and how they fit into a broader strategy of dynamic, intelligent testing:
 
 - **Manual Triggering on Local Hosts:**
-
   - **Developer-Driven Testing:** In the early stages of development, testing is often manually triggered by developers on their local machines. This approach allows developers to quickly validate changes before committing code to the main repository.
   - **Ad Hoc Testing:** This method is often used for exploratory testing or when a developer wants to run a specific subset of tests to verify a particular piece of functionality.
 
 - **Scheduled Test Runners:**
-
   - **Regular Interval Testing:** In many teams, test execution is scheduled to run at regular intervals, such as nightly or weekly. This ensures that the entire test suite is run consistently, catching any regressions that may have been introduced since the last run.
   - **Automated Batch Testing:** Scheduled runners can execute large batches of tests during off-hours, reducing the impact on development resources while still maintaining regular test coverage.
 
 - **CI/CD-Driven Testing:**
-
   - **Scheduled CI/CD Runs:** Continuous Integration (CI) pipelines often include scheduled test runs that occur at specific stages in the development cycle. For example, tests may be scheduled to run after each build or before a release candidate is deployed.
   - **Triggered by Code Changes:** A more dynamic approach within CI/CD environments is to trigger test runs based on code changes, such as commits or pull requests. This ensures that tests are run on the most recent version of the code, providing immediate feedback on the impact of those changes.
     - **Commit-Based Triggering:** Tests are automatically run whenever code is committed to the repository, providing developers with quick feedback on their changes.

--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -166,6 +166,14 @@ const HomeHeroVibe = () => {
         handleAppTypeChange={handleAppTypeChange}
       />
 
+      <p className="relative z-10 max-w-2xl mx-auto text-center text-sm text-gray-500 dark:text-gray-400 px-6">
+        What are AI testing agents? They are AI agents that explore your web
+        application, create end-to-end tests, and self-heal when the UI changes.
+        Wopee.io delivers this on a Playwright foundation — no code, one-minute
+        setup, and continuous regression coverage that scales with your release
+        pace.
+      </p>
+
       <LoginDialog
         appUrl={appUrl}
         appType={appType}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import Layout from "@theme/Layout";
+import Head from "@docusaurus/Head";
 
 import HomeHeroVibe from "@/components/home-page/HomeHeroVibe";
 import HomeSocialProof from "@/components/home-page/HomeSocialProof";
@@ -14,7 +15,13 @@ import HomeFaqSection from "@/components/home-page/HomeFaqSection";
 
 export default function Home(): JSX.Element {
   return (
-    <Layout>
+    <Layout title="AI Testing Agents for Web Apps">
+      <Head>
+        <meta
+          name="description"
+          content="Stop writing tests manually. Wopee.io AI agents explore your app, generate Playwright tests, and self-heal when your UI changes. Try free."
+        />
+      </Head>
       <HomeHeroVibe />
       <HomeBenefits />
       <HomeHowItWorks />


### PR DESCRIPTION
## Summary
- **Homepage**: unique `<title>`, meta description, and AIO opener paragraph inside hero gradient
- **Self-healing blog**: new title, `description` frontmatter, rewritten AIO opening paragraph
- **Predictive testing blog**: new title, `description` frontmatter, rewritten AIO opening paragraph
- **BDD blog**: new title, `description` frontmatter, rewritten AIO opening paragraph

Fixes all four pages having zero custom meta descriptions and weak/missing AIO-ready openings.

Closes marcel-veselka/vem-agents#84

## Test plan
- [x] Verify homepage title renders as "AI Testing Agents for Web Apps | Wopee.io..."
- [x] Verify homepage meta description in page source
- [x] Verify AIO paragraph visible inside hero gradient (both light/dark mode)
- [x] Verify blog post titles updated in browser tab and blog listing
- [x] Verify blog post meta descriptions in page source
- [x] Verify blog post AIO openers render as first paragraph before truncate