### PR TITLE
seo: fix meta descriptions, H1, OG tags, and noindex for remaining pages

### DIFF
--- a/src/pages/book-demo/index.tsx
+++ b/src/pages/book-demo/index.tsx
@@ -1,24 +1,17 @@
 import React from "react";
 import { Helmet } from "react-helmet";
-import Head from "@docusaurus/Head";
 
+import Layout from "@theme/Layout";
 import GoBack from "@site/src/components/demo/GoBack";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import PartnersCarousel from "@site/src/components/demo/PartnersCarousel";
 
 export default function Home(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
-
   return (
-    <React.Fragment>
-      <Head>
-        <title>Book Demo - {siteConfig.title}</title>
-      </Head>
+    <Layout
+      title="Book a Demo | Wopee.io"
+      description="Book a live demo of Wopee.io AI testing agents. See how autonomous test generation and self-healing tests can cut your QA effort by 70%."
+    >
       <Helmet>
-        <meta
-          name="description"
-          content="Book Demo - Autonomous testing platform for web applications | Wopee.io"
-        />
         <script
           type="text/javascript"
           src="https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"
@@ -32,6 +25,6 @@ export default function Home(): JSX.Element {
         ></div>
         <PartnersCarousel />
       </div>
-    </React.Fragment>
+    </Layout>
   );
 }

--- a/src/pages/gdpr/index.md
+++ b/src/pages/gdpr/index.md
@@ -1,6 +1,13 @@
 ---
 title: Data Processing Agreement
+custom_edit_url: null
 ---
+
+import Head from '@docusaurus/Head';
+
+<Head>
+  <meta name="robots" content="noindex, nofollow" />
+</Head>
 
 # Data Processing Agreement
 

--- a/src/pages/jan-beranek/index.tsx
+++ b/src/pages/jan-beranek/index.tsx
@@ -1,14 +1,12 @@
 import React from "react";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 import Layout from "@theme/Layout";
 import { Helmet } from "react-helmet";
 
 export default function Home(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
-      description="Autonomous testing platform for web applications | Wopee.io"
+      title="Book a Meeting with Jan | Wopee.io"
+      description="Schedule a meeting with Jan Beránek from Wopee.io. Discuss AI test automation, onboarding, or product questions."
     >
       <Helmet>
         <script

--- a/src/pages/l/index.tsx
+++ b/src/pages/l/index.tsx
@@ -55,7 +55,10 @@ function HomeHeader() {
 
 export default function Home(): JSX.Element {
   return (
-    <Layout>
+    <Layout
+      title="AI Testing Agents for Web Apps | Wopee.io"
+      description="Stop writing tests manually. Wopee.io AI agents explore your app, generate Playwright tests, and self-heal when your UI changes. Try free."
+    >
       <HomeHeader />
       <main className="container">
         <HomeComparison />

--- a/src/pages/marcel/index.tsx
+++ b/src/pages/marcel/index.tsx
@@ -1,20 +1,16 @@
 import React from "react";
 import { Helmet } from "react-helmet";
 
+import Layout from "@theme/Layout";
 import GoBack from "@site/src/components/demo/GoBack";
-import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
 
 export default function Home(): JSX.Element {
-  const { siteConfig } = useDocusaurusContext();
-
   return (
-    <React.Fragment>
+    <Layout
+      title="Book a Meeting with Marcel | Wopee.io"
+      description="Schedule a meeting with Marcel Veselka, co-founder of Wopee.io. Discuss AI test automation, partnerships, or product questions."
+    >
       <Helmet>
-        <title>{siteConfig.title}</title>
-        <meta
-          name="description"
-          content="Autonomous testing platform for web applications | Wopee.io"
-        />
         <script
           type="text/javascript"
           src="https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"
@@ -27,6 +23,6 @@ export default function Home(): JSX.Element {
           data-src="https://meetings-eu1.hubspot.com/marcel-veselka?embed=true"
         ></div>
       </div>
-    </React.Fragment>
+    </Layout>
   );
 }

--- a/src/pages/newsletter/index.tsx
+++ b/src/pages/newsletter/index.tsx
@@ -12,11 +12,7 @@ const NewsletterPage = () => {
       <main className="container">
         <div className="flex flex-col mt-3 md:mt-5 gap-y-5 gap-x-5 justify-center items-center sm:flex-row">
         <iframe width="540" height="605" src="https://02c03965.sibforms.com/serve/MUIFAF3Jz4xJoDu9MiweeSL7qo0c1HmPyK3TbcNuNmzrmWk4pmpbUP5H0zLvg-sTC2LgnfR8tc02o8Z8b0dzsjs6s-2WTzWtJ19Xj3Skm1NAZKE67qC913KkPowC_kEI8ow55zJ45Mbhmvs5d2v2eqvNYJNyXUrNoh2hQmQ4zXMQfP8903JxYiBCwUBEnAlN-it4TSNjVtffc5TF" frameborder="0" scrolling="auto" allowfullscreen ></iframe>
-          {/* <div className="card flex md:h-[500px] xl:h-[450px] flex-col justify-center items-center sm:w-1/2 p-10 gap-2 xl:gap-5 shadow-xl">
-            <h1>Newsletter</h1>
-            <p>Subscribe to our newsletter to get the latest updates.</p>
-            <div id="newsletter-form-container"></div>
-          </div> */}
+          <h1 className="sr-only">Newsletter</h1>
         </div>
         <NewsletterForm />
       </main>

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -33,7 +33,11 @@ const TestWarez = () => {
   }, []);
 
   return (
-    <Layout wrapperClassName="dark:bg-gray-100">
+    <Layout
+      title="Get Started with Wopee.io | Onboarding"
+      description="Set up your Wopee.io account and start testing your web app in minutes. AI-powered test generation — no coding required."
+      wrapperClassName="dark:bg-gray-100"
+    >
       <div className="container">
         {isLoading ? (
           <div className="flex justify-center items-center h-[50vh]">

--- a/src/pages/toc/index.tsx
+++ b/src/pages/toc/index.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from "react";
+import Head from "@docusaurus/Head";
 
 import { useHistory } from "@docusaurus/router";
 
@@ -9,6 +10,12 @@ const OldTermsPage = () => {
     router.push("/terms-and-conditions");
   }, []);
 
-  return <></>;
+  return (
+    <>
+      <Head>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
+    </>
+  );
 };
 export default OldTermsPage;

--- a/src/pages/ux/index.tsx
+++ b/src/pages/ux/index.tsx
@@ -33,7 +33,11 @@ const UserTestingProgram = () => {
   }, []);
 
   return (
-    <Layout wrapperClassName="dark:bg-gray-100">
+    <Layout
+      title="User Testing Program | Wopee.io"
+      description="Join the Wopee.io user testing program. Help shape the future of AI-powered test automation and get early access to new features."
+      wrapperClassName="dark:bg-gray-100"
+    >
       <div className="container">
         {isLoading ? (
           <div className="flex justify-center items-center h-[50vh]">


### PR DESCRIPTION
## Summary

Completes remaining items from #138 not covered in PR #145.

**Meta descriptions + OG tags fixed:**
- `/l` — add title + description to Layout
- `/onboarding` — add title + description to Layout
- `/ux` — add title + description to Layout
- `/book-demo` — migrate from `React.Fragment` to `<Layout>` (was blocking OG tag generation)
- `/marcel` — migrate from `React.Fragment` to `<Layout>` (was blocking OG tag generation)
- `/jan-beranek` — replace generic siteConfig.title with specific title + description

**H1 fixed:**
- `/newsletter` — uncomment H1 (rendered as `sr-only` so it doesn't affect visual layout)

**Noindex added:**
- `/gdpr` — legal page, should not be indexed
- `/toc` — redirect page to `/terms-and-conditions`, should not be indexed

## Test plan

- [x] Verify meta tags on /book-demo, /marcel, /jan-beranek, /l, /onboarding, /ux (DevTools → Elements → `<head>`)
- [x] Confirm `og:description` now present on migrated pages
- [x] Confirm `/gdpr` and `/toc` return `<meta name="robots" content="noindex, nofollow">`

Closes part of marcel-veselka/vem-agents#138