### PR TITLE
seo: add noindex to booking and form pages

### DIFF
--- a/src/pages/book-demo/index.tsx
+++ b/src/pages/book-demo/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
+import Head from "@docusaurus/Head";
 
 import Layout from "@theme/Layout";
 import GoBack from "@site/src/components/demo/GoBack";
@@ -11,6 +12,9 @@ export default function Home(): JSX.Element {
       title="Book a Demo | Wopee.io"
       description="Book a live demo of Wopee.io AI testing agents. See how autonomous test generation and self-healing tests can cut your QA effort by 70%."
     >
+      <Head>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
       <Helmet>
         <script
           type="text/javascript"

--- a/src/pages/jan-beranek/index.tsx
+++ b/src/pages/jan-beranek/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Layout from "@theme/Layout";
+import Head from "@docusaurus/Head";
 import { Helmet } from "react-helmet";
 
 export default function Home(): JSX.Element {
@@ -8,6 +9,9 @@ export default function Home(): JSX.Element {
       title="Book a Meeting with Jan | Wopee.io"
       description="Schedule a meeting with Jan Beránek from Wopee.io. Discuss AI test automation, onboarding, or product questions."
     >
+      <Head>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
       <Helmet>
         <script
           type="text/javascript"

--- a/src/pages/marcel/index.tsx
+++ b/src/pages/marcel/index.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Helmet } from "react-helmet";
+import Head from "@docusaurus/Head";
 
 import Layout from "@theme/Layout";
 import GoBack from "@site/src/components/demo/GoBack";
@@ -10,6 +11,9 @@ export default function Home(): JSX.Element {
       title="Book a Meeting with Marcel | Wopee.io"
       description="Schedule a meeting with Marcel Veselka, co-founder of Wopee.io. Discuss AI test automation, partnerships, or product questions."
     >
+      <Head>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
       <Helmet>
         <script
           type="text/javascript"

--- a/src/pages/onboarding/index.tsx
+++ b/src/pages/onboarding/index.tsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useState } from "react";
+import Head from "@docusaurus/Head";
 
 import Layout from "@theme/Layout";
 
@@ -38,6 +39,9 @@ const TestWarez = () => {
       description="Set up your Wopee.io account and start testing your web app in minutes. AI-powered test generation — no coding required."
       wrapperClassName="dark:bg-gray-100"
     >
+      <Head>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
       <div className="container">
         {isLoading ? (
           <div className="flex justify-center items-center h-[50vh]">

--- a/src/pages/ux/index.tsx
+++ b/src/pages/ux/index.tsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useState } from "react";
+import Head from "@docusaurus/Head";
 
 import Layout from "@theme/Layout";
 
@@ -38,6 +39,9 @@ const UserTestingProgram = () => {
       description="Join the Wopee.io user testing program. Help shape the future of AI-powered test automation and get early access to new features."
       wrapperClassName="dark:bg-gray-100"
     >
+      <Head>
+        <meta name="robots" content="noindex, nofollow" />
+      </Head>
       <div className="container">
         {isLoading ? (
           <div className="flex justify-center items-center h-[50vh]">


### PR DESCRIPTION
## Summary

Adds `noindex, nofollow` to 5 utility pages that should not appear in search results:

| Page | Type |
|------|------|
| `/book-demo` | HubSpot meeting embed |
| `/marcel` | HubSpot meeting embed |
| `/jan-beranek` | HubSpot meeting embed |
| `/onboarding` | HubSpot form |
| `/ux` | HubSpot form (user testing program) |

## Test plan

- [ ] Verify each page has `<meta name="robots" content="noindex, nofollow">` in DevTools → Elements → `<head>`

Closes part of marcel-veselka/vem-agents#138