### PR TITLE
feat: rename /testing-bot to /ai-testing-agents, refresh copy and navigation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -199,7 +199,7 @@ const config = {
             label: "Solutions",
             position: "left",
             items: [
-              { to: "/testing-bot", label: "AI Agents for Software Testing" },
+              { to: "/ai-testing-agents", label: "AI Agents for Software Testing" },
               { to: "/visual-testing", label: "Visual Regression Testing" },
               {
                 to: "blog/playwright-bot-ai-powered-test-automation",
@@ -232,15 +232,15 @@ const config = {
         style: "dark",
         links: [
           {
-            title: "Solutions: Regression Testing",
+            title: "Solutions: AI Testing",
             items: [
-              { label: "Autonomous Testing Bot 🤖", to: "/testing-bot" },
+              { label: "AI Testing Agents 🤖", to: "/ai-testing-agents" },
               {
                 label: "Visual Regression Testing",
                 to: "/visual-testing",
               },
               {
-                label: "Playwright AI Bot (preview)",
+                label: "Playwright AI Agent",
                 to: "blog/playwright-bot-ai-powered-test-automation",
               },
             ],

--- a/src/components/bot-page/HeroSection.tsx
+++ b/src/components/bot-page/HeroSection.tsx
@@ -9,20 +9,20 @@ const HeroSection = () => {
         <div className="text-balance flex flex-col gap-9">
           <h1 className="text-5xl sm:text-6xl">
             <span className="text-secondary-wopee dark:text-primary-wopee">
-              Web Apps Testing
+              AI Testing Agents
             </span>{" "}
-            with AI Agents
+            for Web Apps
           </h1>
 
           <p className="text-2xl">
-            Automate like a pro, 1 minute{" "}
-            <span className="line-clamp-1">setup, no coding required.</span>
+            Autonomous agents that explore, test, and self-heal.{" "}
+            <span className="line-clamp-1">1 minute setup, no coding required.</span>
           </p>
         </div>
 
         <div>
           <ButtonPrimary
-            label="Get early access"
+            label="Start free trial"
             href="https://cmd.wopee.io"
             className="w-60 h-[50px]"
           />

--- a/src/components/bot-page/HowItWorksIntro.tsx
+++ b/src/components/bot-page/HowItWorksIntro.tsx
@@ -27,7 +27,7 @@ const HowItWorksIntro = () => {
 
       <div className="px-2 lg:px-0">
         <ButtonPrimary
-          label="Get early access"
+          label="Start free trial"
           href="https://cmd.wopee.io"
           className="w-60 h-[50px]"
         />

--- a/src/components/home-page/HomeProductCards.tsx
+++ b/src/components/home-page/HomeProductCards.tsx
@@ -6,7 +6,7 @@ const SelfDrivingBotCard = () => {
   const router = useHistory();
   return (
     <div
-      onClick={() => router.push("/testing-bot")}
+      onClick={() => router.push("/ai-testing-agents")}
       className="flex items-center justify-around w-[355px] sm:w-[530px] xl:w-[600px] h-[195px] py-4 rounded-lg border hover:ring-2 hover:ring-primary-wopee border-solid border-primary-wopee bg-gradient-to-br from-secondary-wopee to-white hover:cursor-pointer transition-shadow ease-in-out"
     >
       <div className="flex flex-col w-1/2 gap-4 items-center">
@@ -23,7 +23,7 @@ const SelfDrivingBotCard = () => {
           </h3>
         </section>
 
-        <Link to="/testing-bot" className="group">
+        <Link to="/ai-testing-agents" className="group">
           <button className=" text-white border border-secondary-wopee font-semibold bg-transparent group-hover:bg-secondary-wopee group-hover:text-white hover:cursor-pointer rounded-lg text-sm md:text-base xl:text-lg px-5 py-1 text-center transition ease-out">
             Learn more
           </button>

--- a/src/components/legacy/home-page/HomeSolutions.tsx
+++ b/src/components/legacy/home-page/HomeSolutions.tsx
@@ -35,7 +35,7 @@ export default function HomepageHowItWorks(): JSX.Element {
         <div className="card flex flex-1 p-5 md:p-10 justify-between gap-5 shadow-lg">
           <div className="flex flex-col justify-between h-full gap-2">
             <h3 className="text-lg md:text-xl xl:text-2xl font-bold text-secondary-wopee dark:text-primary-wopee">
-              <Link to="/testing-bot">
+              <Link to="/ai-testing-agents">
                 <span className="flex items-center justify-center gap-1">
                   Autonomous Testing Bot <LinkIcon />
                 </span>
@@ -46,7 +46,7 @@ export default function HomepageHowItWorks(): JSX.Element {
             </p>
             <div className="flex justify-center items-center">
               <Link
-                to="/testing-bot"
+                to="/ai-testing-agents"
                 className="group"
               >
                 <Icon
@@ -75,7 +75,7 @@ export default function HomepageHowItWorks(): JSX.Element {
             <p className="text-sm md:text-lg xl:text-xl text-center">
               It is just that simple!
               <Link
-                to="/testing-bot"
+                to="/ai-testing-agents"
                 className="ml-2"
               >
                 Read more..

--- a/src/pages/ai-testing-agents/index.tsx
+++ b/src/pages/ai-testing-agents/index.tsx
@@ -1,0 +1,105 @@
+import {
+  mdiRocket,
+  mdiRunFast,
+  mdiCurrencyUsd,
+  mdiCheckboxMultipleOutline,
+} from "@mdi/js";
+import React from "react";
+
+import Layout from "@theme/Layout";
+import HeroSection from "@site/src/components/bot-page/HeroSection";
+import PartnerBrands from "@site/src/components/landing-page/home/sections/PartnerBrands";
+import TestingBottlenecks from "@site/src/components/bot-page/TestingBottlenecks";
+import WopeeVersusSection from "@site/src/components/landing-page/home/sections/WopeeVersusSection";
+import HowItWorksIntro from "@site/src/components/bot-page/HowItWorksIntro";
+import HowItWorks from "@site/src/components/landing-page/home/sections/HowItWorks";
+import TestimonialCarousel from "@site/src/components/landing-page/home/sections/TestimonialCarousel";
+import EndingSection from "@site/src/components/landing-page/home/sections/EndingSection";
+
+const STEPS = [
+  {
+    title: "Effortless setup:",
+    subtitle: "Get started in 1 minute",
+    description:
+      "Point your AI agent at any web app and it starts exploring immediately. No scripts, no selectors, no programming required. The agent autonomously crawls your application, discovers user flows, and generates Playwright test cases automatically.",
+  },
+  {
+    image: "/img/landing/instant-results.png",
+    alt: "dashboard-testing-results",
+    title: "Autonomous testing:",
+    subtitle: "Results ready in 2 minutes",
+    description:
+      "Your AI agent runs generated tests across browsers, performing visual and functional validations. When your UI changes, tests self-heal instead of breaking. Within minutes, you get detailed results with screenshots, traces, and video recordings.",
+  },
+  {
+    image: "/img/landing/comparison-view.png",
+    alt: "comparison-view",
+    title: "Simplified Maintenance:",
+    subtitle: "Adapt and optimize with ease",
+    description:
+      "Traditional test frameworks break with every UI change. Wopee.io agents adapt automatically. Approve visual baseline updates with a single click, or report bugs directly. Your team focuses on shipping, not fixing flaky tests.",
+  },
+];
+
+const FEATURES = [
+  "AI-powered test generation",
+  "Scheduled test runs",
+  "Video recording and traces",
+  "Self-healing tests",
+  "Playwright test export",
+  "Multi-browser execution",
+  "Autonomous visual testing",
+  "Exploratory testing",
+  "Mobile browser testing",
+  "Autonomous functional testing",
+  "Multi-configuration support",
+  "Priority-based testing",
+];
+
+const VALUES = [
+  {
+    icon: mdiRocket,
+    title: "10x",
+    description: "Quicker preparation",
+  },
+  {
+    icon: mdiCurrencyUsd,
+    title: "30 - 40%",
+    description: "Cheaper maintenance",
+  },
+  {
+    icon: mdiCheckboxMultipleOutline,
+    title: "5x",
+    description: "Higher coverage",
+  },
+  {
+    icon: mdiRunFast,
+    title: "50 - 70%",
+    description: "Quicker execution",
+  },
+];
+
+const AiTestingAgentsPage = () => {
+  return (
+    <Layout
+      title="AI Testing Agents | Wopee.io"
+      description="Autonomous AI testing agents that explore your web app, generate Playwright tests, and self-heal when your UI changes. Start testing in minutes, no coding required."
+    >
+      <HeroSection />
+      <PartnerBrands />
+      <TestingBottlenecks />
+      <WopeeVersusSection
+        bot
+        VALUES={VALUES}
+      />
+      <HowItWorksIntro />
+      <HowItWorks
+        STEPS={STEPS}
+        FEATURES={FEATURES}
+      />
+      <TestimonialCarousel />
+      <EndingSection bot />
+    </Layout>
+  );
+};
+export default AiTestingAgentsPage;

--- a/src/pages/bot/index.tsx
+++ b/src/pages/bot/index.tsx
@@ -6,7 +6,7 @@ const BotPage = () => {
   const router = useHistory();
 
   useEffect(() => {
-    router.push("/testing-bot");
+    router.push("/ai-testing-agents");
   }, []);
 
   return <></>;

--- a/src/pages/testing-bot/index.tsx
+++ b/src/pages/testing-bot/index.tsx
@@ -1,107 +1,14 @@
-import {
-  mdiRocket,
-  mdiRunFast,
-  mdiCurrencyUsd,
-  mdiCheckboxMultipleOutline,
-} from "@mdi/js";
-import React from "react";
+import React, { useEffect } from "react";
 
-import Layout from "@theme/Layout";
-import HeroSection from "@site/src/components/bot-page/HeroSection";
-import PartnerBrands from "@site/src/components/landing-page/home/sections/PartnerBrands";
-import TestingBottlenecks from "@site/src/components/bot-page/TestingBottlenecks";
-import WopeeVersusSection from "@site/src/components/landing-page/home/sections/WopeeVersusSection";
-// import StartTesting from "@site/src/components/bot-page/StartTesting";
-import HowItWorksIntro from "@site/src/components/bot-page/HowItWorksIntro";
-import HowItWorks from "@site/src/components/landing-page/home/sections/HowItWorks";
-import TestimonialCarousel from "@site/src/components/landing-page/home/sections/TestimonialCarousel";
-import EndingSection from "@site/src/components/landing-page/home/sections/EndingSection";
+import { useHistory } from "@docusaurus/router";
 
-const STEPS = [
-  {
-    title: "Effortless setup:",
-    subtitle: "Get started in 1 minute",
-    description:
-      "Simplify the initial setup process and start testing your web app in just one minute. Our intelligent bot automatically crawls your application, generating test cases without any need for programming or complex configurations. This ensures that even teams with limited technical skills can quickly implement and begin testing.",
-  },
-  {
-    image: "/img/landing/instant-results.png",
-    alt: "dashboard-testing-results",
-    title: "Autonomous testing:",
-    subtitle: "Results ready in 2 minutes",
-    description:
-      "Once the setup is complete, Wopee.io takes over with autonomous testing. Our bot runs through the generated test cases, performing both visual and non-visual validations to ensure your application functions as expected. Within just two minutes, you receive detailed results, helping you identify and address potential issues before they impact your users.",
-  },
-  {
-    image: "/img/landing/comparison-view.png",
-    alt: "comparison-view",
-    title: "Simplified Maintenance:",
-    subtitle: "Adapt and optimize with ease",
-    description:
-      "Wopee.io is designed for minimal maintenance. When issues are detected, our platform allows you to update tests with a single click or report bugs directly. This seamless process reduces the time spent on test maintenance, enabling your team to focus on broader testing coverage and enhancing overall efficiency.",
-  },
-];
+const TestingBotRedirect = () => {
+  const router = useHistory();
 
-const FEATURES = [
-  "Automated test generation",
-  "Scheduled test runs",
-  "Video recording of tests",
-  "Bot analysis",
-  "Multi-version support",
-  "Execution traces",
-  "Autonomous visual testing",
-  "Exploratory testing",
-  "Mobile browser testing",
-  "Autonomous non-visual testing",
-  "Multi-configuration support",
-  "Priority-based testing",
-];
+  useEffect(() => {
+    router.push("/ai-testing-agents");
+  }, []);
 
-const VALUES = [
-  {
-    icon: mdiRocket,
-    title: "10x",
-    description: "Quicker preparation",
-  },
-  {
-    icon: mdiCurrencyUsd,
-    title: "30 - 40%",
-    description: "Cheaper maintenance",
-  },
-  {
-    icon: mdiCheckboxMultipleOutline,
-    title: "5x",
-    description: "Higher coverage",
-  },
-  {
-    icon: mdiRunFast,
-    title: "50 - 70%",
-    description: "Quicker execution",
-  },
-];
-
-const TestingBotPage = () => {
-  return (
-    <Layout
-      title="AI Testing Agents | Wopee.io"
-      description="Autonomous AI testing bots that explore your web app, generate Playwright tests, and self-heal when your UI changes. Start testing in minutes — no coding required."
-    >
-      <HeroSection />
-      <PartnerBrands />
-      <TestingBottlenecks />
-      <WopeeVersusSection
-        bot
-        VALUES={VALUES}
-      />
-      {/* <StartTesting /> */}
-      <HowItWorksIntro />
-      <HowItWorks
-        STEPS={STEPS}
-        FEATURES={FEATURES}
-      />
-      <TestimonialCarousel />
-      <EndingSection bot />
-    </Layout>
-  );
+  return <></>;
 };
-export default TestingBotPage;
+export default TestingBotRedirect;


### PR DESCRIPTION
## Summary

- Create `/ai-testing-agents` as canonical page with refreshed AI agents copy (self-healing, Playwright export, autonomous exploration)
- `/testing-bot` and `/bot` redirect to `/ai-testing-agents`
- Update navbar dropdown, footer, and internal component links
- Update CTAs from "Get early access" to "Start free trial"
- Footer renamed: "Solutions: AI Testing", "AI Testing Agents 🤖", "Playwright AI Agent"

Closes #87

## Test plan

- [x] `/ai-testing-agents` renders with updated copy and CTAs
- [x] `/testing-bot` redirects to `/ai-testing-agents`
- [x] `/bot` redirects to `/ai-testing-agents`
- [x] Navbar "Solutions > AI Agents for Software Testing" links correctly
- [x] Footer shows "Solutions: AI Testing" with updated labels