### PR TITLE
fix: suppress Node.js 20 deprecation in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,10 @@ concurrency:
 
 jobs:
   deploy:
+    env:
+      # upload-pages-artifact@v4 (latest) bundles Node 20 internally.
+      # Force Node 24 until the action releases a version with native support.
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- `actions/upload-pages-artifact@v4` is the latest release but internally depends on `actions/upload-artifact` which still runs on Node.js 20
- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to the deploy job to suppress the deprecation warning

## Test plan
- [ ] Verify the deploy workflow runs without Node.js 20 deprecation warnings