### PR TITLE
fix(home): use brand purple for 'Autonomously' accent in light mode

### DIFF
--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -109,7 +109,6 @@ const HomeHeroVibe = () => {
               textShadow:
                 "0 0 40px rgba(112,48,160,0.35), 0 4px 30px rgba(0,0,0,0.15)",
             }}
-            }}
           >
             Autonomously.
           </span>


### PR DESCRIPTION
Follow-up to #163 addressing review feedback: in light mode the yellow 'Autonomously' accent didn't align with the rest of the brand (e.g. Sign In button). Switching to brand purple (`secondary-wopee`) keeps consistency in light mode while preserving the existing `primary-wopee` yellow in dark mode.