### PR TITLE
refactor(ui): unify card styling with shared GradientCard

### DIFF
--- a/src/components/home-page/HomeBenefits.tsx
+++ b/src/components/home-page/HomeBenefits.tsx
@@ -8,6 +8,7 @@ import {
   ClipboardList,
 } from "lucide-react";
 import ButtonPrimary from "../buttons/ButtonPrimary";
+import GradientCard from "@/components/ui/GradientCard";
 import { cmdBaseUrl } from "../../../cmdBaseUrl";
 
 const benefits = [
@@ -87,30 +88,28 @@ const HomeBenefits = () => {
       </p>
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl w-full mb-10">
         {benefits.map((benefit, idx) => (
-          <div
+          <GradientCard
             key={idx}
-            className="group relative rounded-xl transition-shadow min-h-[260px] h-full flex"
+            className="h-full"
+            innerClassName="flex flex-col justify-between min-h-[260px]"
           >
-            <div className="absolute inset-0 rounded-xl pointer-events-none opacity-0 group-hover:opacity-100 transition-opacity duration-300 z-0 bg-gradient-to-br from-blue-500 to-secondary-wopee p-0.5"></div>
-            <div className="relative bg-white/70 dark:bg-black/40 border border-gray-200 dark:border-gray-800 rounded-xl p-6 flex flex-col justify-between shadow-lg hover:shadow-2xl transition-shadow min-h-[260px] h-full w-full backdrop-blur z-10 group-hover:border-transparent">
-              <div>
-                <div className="flex items-center gap-3 mb-2">
-                  <span className="inline-flex items-center justify-center w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-lg">
-                    {benefit.icon}
-                  </span>
-                  <span className="ml-auto px-3 py-1 text-xs rounded-full bg-yellow-100 dark:bg-yellow-900 text-yellow-700 dark:text-yellow-300 font-semibold">
-                    {benefit.badge}
-                  </span>
-                </div>
-                <h3 className="font-bold text-lg text-gray-900 dark:text-white mb-1 min-h-[48px] flex items-center">
-                  {benefit.title}
-                </h3>
-                <p className="text-gray-700 dark:text-gray-300 text-sm">
-                  {benefit.description}
-                </p>
+            <div>
+              <div className="flex items-center gap-3 mb-2">
+                <span className="inline-flex items-center justify-center w-10 h-10 bg-gray-100 dark:bg-gray-800 rounded-lg">
+                  {benefit.icon}
+                </span>
+                <span className="ml-auto px-3 py-1 text-xs rounded-full bg-yellow-100 dark:bg-yellow-900 text-yellow-700 dark:text-yellow-300 font-semibold">
+                  {benefit.badge}
+                </span>
               </div>
+              <h3 className="font-bold text-lg text-gray-900 dark:text-white mb-1 min-h-[48px] flex items-center">
+                {benefit.title}
+              </h3>
+              <p className="text-gray-700 dark:text-gray-300 text-sm">
+                {benefit.description}
+              </p>
             </div>
-          </div>
+          </GradientCard>
         ))}
       </div>
       <ButtonPrimary

--- a/src/components/home-page/HomeDeploymentOptions.tsx
+++ b/src/components/home-page/HomeDeploymentOptions.tsx
@@ -3,69 +3,111 @@ import Link from "@docusaurus/Link";
 import { Cloud, Server } from "lucide-react";
 import { cmdBaseUrl } from "../../../cmdBaseUrl";
 import ButtonPrimary from "../buttons/ButtonPrimary";
+import ButtonGradientOutline from "../buttons/ButtonGradientOutline";
+import GradientCard from "@/components/ui/GradientCard";
+
+type DeploymentCardProps = {
+  title: string;
+  subtitle: string;
+  description: string;
+  icon: React.ReactNode;
+  recommended?: boolean;
+  cta: React.ReactNode;
+};
 
 const DeploymentCard = ({
   title,
+  subtitle,
   description,
-  buttonText,
-  buttonHref,
-  buttonId,
   icon,
-}: {
-  title: string;
-  description: string;
-  buttonText: string;
-  buttonHref: string;
-  buttonId?: string;
-  icon: React.ReactNode;
-}) => {
-  return (
-    <div className="flex flex-col justify-between p-8 rounded-2xl bg-gradient-to-br from-secondary-wopee to-purple-800 text-white h-80 max-w-lg hover:shadow-xl transition-shadow duration-300">
+  recommended,
+  cta,
+}: DeploymentCardProps) => {
+  const body = (
+    <>
+      {recommended && (
+        <span className="absolute top-5 right-5 px-3 py-1 text-[10px] font-semibold uppercase tracking-wider rounded-full bg-primary-wopee text-secondary-wopee">
+          Recommended
+        </span>
+      )}
       <div>
-        <div className="flex items-center gap-3 mb-6">
-          <div className="text-primary-wopee">{icon}</div>
-          <h3 className="text-3xl font-bold">{title}</h3>
+        <div className="flex items-center gap-4 mb-6">
+          <div className="text-primary-wopee shrink-0">{icon}</div>
+          <div>
+            <h3 className="text-3xl font-bold leading-tight m-0">{title}</h3>
+            <p className="text-sm font-medium uppercase tracking-wider opacity-70 mt-1 m-0">
+              {subtitle}
+            </p>
+          </div>
         </div>
         <p className="text-lg leading-relaxed opacity-90">{description}</p>
       </div>
+      <div className="mt-8">{cta}</div>
+    </>
+  );
 
-      <ButtonPrimary
-        id={buttonId}
-        className="w-full font-semibold rounded-lg px-8 py-4 text-lg !bg-primary-wopee !text-secondary-wopee group-hover:!text-white group-hover:!bg-secondary-wopee group-hover:!border-primary-wopee"
-        label={buttonText}
-        href={buttonHref}
-      />
-    </div>
+  if (recommended) {
+    return (
+      <GradientCard
+        variant="solid"
+        padding="roomy"
+        className="relative flex flex-col justify-between w-full max-w-md h-full"
+      >
+        {body}
+      </GradientCard>
+    );
+  }
+
+  return (
+    <GradientCard
+      padding="roomy"
+      className="w-full max-w-md h-full"
+      innerClassName="relative flex flex-col justify-between"
+    >
+      {body}
+    </GradientCard>
   );
 };
 
 const HomeDeploymentOptions = () => {
   return (
-    <section className="py-16 bg-slate-50 dark:bg-slate-900">
+    <section className="py-16">
       <div className="container mx-auto px-4">
         <div className="text-center mb-12">
-          <h2 className="text-4xl font-bold text-slate-800 dark:text-white mb-4">
-            Deploy on your terms
-          </h2>
+          <h2 className="text-4xl font-bold mb-4">Deploy on your terms</h2>
+          <p className="text-lg text-gray-700 dark:text-gray-300 max-w-2xl mx-auto">
+            Most teams start in the cloud — switch to self-hosted whenever you
+            need to.
+          </p>
         </div>
 
-        <div className="flex flex-col lg:flex-row gap-6 justify-center items-center max-w-6xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 justify-center items-stretch max-w-5xl mx-auto">
           <DeploymentCard
-            title="Cloud (fully managed)"
+            title="Cloud"
+            subtitle="Fully managed"
             description="Focus on shipping. We take care of the rest (host, scale & update everything)."
-            buttonText="Start testing better now"
-            buttonHref={cmdBaseUrl}
-            buttonId="cta-deploy-cloud"
             icon={<Cloud size={40} />}
+            recommended
+            cta={
+              <ButtonPrimary
+                id="cta-deploy-cloud"
+                className="w-full font-semibold rounded-lg px-8 py-4 text-lg !bg-primary-wopee !text-secondary-wopee"
+                label="Start testing better now"
+                href={cmdBaseUrl}
+              />
+            }
           />
 
           <DeploymentCard
-            title="On-Prem (self-hosted)"
+            title="On-Prem"
+            subtitle="Self-hosted"
             description="Run Wopee.io inside your own CI/CD. Get more control over security."
-            buttonText="Book demo"
-            buttonHref="/book-demo"
-            buttonId="cta-deploy-onprem"
             icon={<Server size={40} />}
+            cta={
+              <Link to="/book-demo" id="cta-deploy-onprem">
+                <ButtonGradientOutline className="w-full" label="Book demo" />
+              </Link>
+            }
           />
         </div>
       </div>

--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -28,7 +28,7 @@ Wait for page load, accept cookies (if shown), submit form with pre-filled PIN.`
   },
   [AppType.YOUR_APPLICATION]: {
     url: "",
-    instructions: "Your testing instructions..",
+    instructions: "Open homepage, accept cookies if prompted, suggest what to test.",
   },
 };
 const urlList = Object.entries(appTemplates).map(([key, value]) => ({

--- a/src/components/pricing/PlanCard.tsx
+++ b/src/components/pricing/PlanCard.tsx
@@ -1,9 +1,9 @@
-import clsx from "clsx";
 import React from "react";
 
 import Ribbon from "./Ribbon";
 import Link from "@docusaurus/Link";
 import ButtonGradientOutline from "../buttons/ButtonGradientOutline";
+import GradientCard from "@/components/ui/GradientCard";
 
 type PlanCardT = {
   img: string;
@@ -64,11 +64,10 @@ export default function PlanCard({
   featured,
 }: PlanCardT) {
   return (
-    <div
-      className={clsx(
-        "card flex flex-col items-center h-[560px] w-[335px] justify-center gap-5 p-5 shadow-xl",
-        featured ? "relative overflow-hidden xl:scale-105 " : ""
-      )}
+    <GradientCard
+      variant={featured ? "featured" : "default"}
+      className="h-[560px] w-[335px]"
+      innerClassName="flex flex-col items-center justify-center gap-5 relative overflow-hidden"
     >
       {featured && <Ribbon />}
       {img ? (
@@ -99,6 +98,6 @@ export default function PlanCard({
         </h4>
       </div>
       {button}
-    </div>
+    </GradientCard>
   );
 }

--- a/src/components/pricing/Pricing.tsx
+++ b/src/components/pricing/Pricing.tsx
@@ -4,6 +4,7 @@ import PlanComparison from "./PlanComparison";
 import PlanCard, { PlanCards } from "./PlanCard";
 import Link from "@docusaurus/Link";
 import ButtonGradientOutline from "../buttons/ButtonGradientOutline";
+import GradientCard from "@/components/ui/GradientCard";
 
 export default function Pricing(): JSX.Element {
   return (
@@ -22,7 +23,10 @@ export default function Pricing(): JSX.Element {
           ))}
         </div>
 
-        <div className="card p-5 shadow-[0_0_10px_0] shadow-secondary-wopee dark:shadow-primary-wopee gap-5 h-[560px] w-[335px] md:w-auto md:h-auto md:flex-row items-center">
+        <GradientCard
+          className="w-[335px] md:w-auto"
+          innerClassName="flex flex-col md:flex-row gap-5 h-[560px] md:h-auto items-center"
+        >
           <img
             src="/img/subscription-plans/enterprise.png"
             alt="enterprise-plan-card"
@@ -54,7 +58,7 @@ export default function Pricing(): JSX.Element {
               />
             </Link>
           </div>
-        </div>
+        </GradientCard>
       </div>
 
       <div className="my-5">

--- a/src/components/ui/GradientCard.tsx
+++ b/src/components/ui/GradientCard.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { cn } from "@/lib/utils";
+
+type Variant = "default" | "featured" | "solid";
+type Padding = "compact" | "default" | "roomy" | "none";
+
+const PADDINGS: Record<Padding, string> = {
+  none: "",
+  compact: "p-4",
+  default: "p-5 sm:p-6",
+  roomy: "p-8 lg:p-12",
+};
+
+export interface GradientCardProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * default = gradient ring + dark inner (matches homepage hero)
+   * featured = same ring with brighter shadow + xl:scale-105
+   * solid = single layer, solid purple gradient surface (for CTA cards)
+   */
+  variant?: Variant;
+  padding?: Padding;
+  /** Classes applied to the inner surface (default/featured variants only). */
+  innerClassName?: string;
+}
+
+const GradientCard = React.forwardRef<HTMLDivElement, GradientCardProps>(
+  (
+    {
+      variant = "default",
+      padding = "default",
+      className,
+      innerClassName,
+      children,
+      ...rest
+    },
+    ref
+  ) => {
+    if (variant === "solid") {
+      return (
+        <div
+          ref={ref}
+          className={cn(
+            "rounded-2xl bg-gradient-to-br from-secondary-wopee to-purple-800 text-white shadow-2xl shadow-purple-900/50",
+            PADDINGS[padding],
+            className
+          )}
+          {...rest}
+        >
+          {children}
+        </div>
+      );
+    }
+
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "p-[1.5px] rounded-2xl bg-gradient-to-br from-secondary-wopee via-purple-500 to-primary-wopee shadow-2xl",
+          variant === "featured"
+            ? "shadow-purple-900/70 xl:scale-105"
+            : "shadow-purple-900/50",
+          className
+        )}
+        {...rest}
+      >
+        <div
+          className={cn(
+            "bg-white dark:bg-gray-900 rounded-[14px] h-full",
+            PADDINGS[padding],
+            innerClassName
+          )}
+        >
+          {children}
+        </div>
+      </div>
+    );
+  }
+);
+GradientCard.displayName = "GradientCard";
+
+export default GradientCard;

--- a/src/components/ui/VideoCard.tsx
+++ b/src/components/ui/VideoCard.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useRef, useCallback, useEffect } from "react";
+import GradientCard from "./GradientCard";
 
 interface VideoCardProps {
   videoSrc: string;
@@ -68,13 +69,14 @@ export default function VideoCard({
   }, [videoLoading]);
 
   return (
-    <div
+    <GradientCard
       ref={cardRef}
-      className={`bg-gradient-to-r from-purple-600 to-pink-600 rounded-2xl p-1 shadow-2xl ${className}`}
+      padding="none"
+      className={className}
+      innerClassName="bg-[#1a1a2e] dark:bg-[#1a1a2e] p-1 relative group overflow-hidden"
     >
-      <div className="bg-[#1a1a2e] rounded-xl p-1 relative group overflow-hidden">
-        {/* Video or Fallback Image */}
-        {!videoError ? (
+      {/* Video or Fallback Image */}
+      {!videoError ? (
           <video
             ref={videoRef}
             autoPlay
@@ -136,8 +138,7 @@ export default function VideoCard({
               />
             </svg>
           </button>
-        )}
-      </div>
-    </div>
+      )}
+    </GradientCard>
   );
 }

--- a/src/pages/mcp/index.tsx
+++ b/src/pages/mcp/index.tsx
@@ -18,6 +18,7 @@ import Layout from "@theme/Layout";
 import ButtonPrimary from "@site/src/components/buttons/ButtonPrimary";
 import TestimonialCarousel from "@site/src/components/landing-page/home/sections/TestimonialCarousel";
 import ButtonPrimaryInverted from "@site/src/components/buttons/ButtonPrimaryInverted";
+import GradientCard from "@site/src/components/ui/GradientCard";
 
 const CAPABILITIES = [
   {
@@ -336,9 +337,9 @@ const CapabilitiesSection = () => (
 
     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
       {CAPABILITIES.map((cap) => (
-        <div
+        <GradientCard
           key={cap.title}
-          className="group border border-solid border-gray-200 dark:border-gray-700 rounded-xl p-6 hover:border-secondary-wopee dark:hover:border-primary-wopee transition-all hover:shadow-xl hover:-translate-y-1 bg-white dark:bg-gray-900/50"
+          className="group transition-transform hover:-translate-y-1"
         >
           <div className="w-14 h-14 rounded-xl bg-secondary-wopee/15 dark:bg-primary-wopee/15 flex items-center justify-center mb-4 group-hover:scale-110 transition-transform">
             <Icon
@@ -352,7 +353,7 @@ const CapabilitiesSection = () => (
             {cap.tool}
           </code>
           <p className="opacity-70 text-balance">{cap.description}</p>
-        </div>
+        </GradientCard>
       ))}
     </div>
 
@@ -411,8 +412,8 @@ const HowItWorksSection = () => (
                     : "conversation"}
                 </span>
               </div>
-              <pre className="p-5 text-sm sm:text-base text-gray-300 overflow-x-auto">
-                <code>{step.code}</code>
+              <pre className="!bg-transparent p-5 text-sm sm:text-base !text-gray-300 overflow-x-auto m-0">
+                <code className="!bg-transparent !text-gray-300">{step.code}</code>
               </pre>
             </div>
           </div>
@@ -493,13 +494,17 @@ const CompatibleToolsSection = () => (
 
 const OpenSourceSection = () => (
   <div className="container my-16 lg:my-24 px-5 lg:px-10">
-    <div className="bg-gradient-to-r from-gray-50 to-gray-100 dark:from-gray-800 dark:to-gray-900 rounded-2xl p-8 lg:p-12 flex flex-col lg:flex-row items-center gap-8">
+    <GradientCard
+      variant="solid"
+      padding="roomy"
+      className="flex flex-col lg:flex-row items-center gap-8"
+    >
       <div className="flex-1">
         <div className="flex items-center gap-2 mb-4">
           <Icon
             path={mdiGithub}
             size={1.5}
-            className="text-secondary-wopee dark:text-primary-wopee"
+            className="text-primary-wopee"
           />
         </div>
         <h2 className="text-3xl lg:text-4xl font-bold mb-4">
@@ -539,14 +544,14 @@ const OpenSourceSection = () => (
             ["wopee_create_blank_suite", "Create new suite"],
             ["wopee_fetch_analysis_suites", "List all suites"],
           ].map(([tool, desc]) => (
-            <div key={tool} className="flex items-center gap-3 px-4 py-3 rounded-lg bg-gray-100 dark:bg-gray-800 border border-gray-200 dark:border-gray-700">
-              <code className="text-sm text-secondary-wopee dark:text-primary-wopee font-semibold">{tool}</code>
-              <span className="text-sm opacity-60 hidden sm:inline">— {desc}</span>
+            <div key={tool} className="flex items-center gap-3 px-4 py-3 rounded-lg bg-black/40 border border-white/10">
+              <code className="!bg-transparent !border-0 !p-0 text-sm !text-primary-wopee font-semibold">{tool}</code>
+              <span className="text-sm text-white/80 hidden sm:inline">— {desc}</span>
             </div>
           ))}
         </div>
       </div>
-    </div>
+    </GradientCard>
   </div>
 );
 


### PR DESCRIPTION
## Summary

Cards across the marketing site had drifted into 5+ visual styles (flat gray borders, hover-only blue→purple gradient, solid purple panels, Infima `.card` with yellow glow, MCP tiles, etc.). This PR introduces one shared `<GradientCard>` component and refactors every distinct tile to use it, so the homepage hero's gradient-bordered card becomes the consistent visual language across the site.

## New component

`src/components/ui/GradientCard.tsx` — three variants:
- **default** — 1.5px purple→pink→yellow gradient ring + dark inner + deep purple shadow (matches the homepage hero)
- **featured** — same ring, brighter shadow, `xl:scale-105`
- **solid** — single-layer purple gradient surface for CTA cards (no inner)

Padding presets: `none` / `compact` / `default` / `roomy`. `innerClassName` escape hatch via `tailwind-merge` for special cases (e.g. VideoCard's `#1a1a2e` media surface).

## Refactored

| Component | Before | After |
|---|---|---|
| `HomeBenefits` 6-up feature grid | hover-only blue→purple ring, semi-transparent inner | always-on brand ring |
| `VideoCard` | purple→pink ring | matches the hero ring |
| `HomeDeploymentOptions` | two identical purple cards on a slate section bg, awkward title wrapping | **Cloud** is the visually primary \`Recommended\` option (`solid`), **On-Prem** uses the `default` ring as a deliberate alternative; titles split into headline + uppercase subtitle (\`Cloud\` / \`Fully managed\`, \`On-Prem\` / \`Self-hosted\`); slate bg dropped; intro subtitle added; equal heights via `items-stretch` + `h-full` |
| `PlanCard` (pricing) | Infima `.card` + scale on featured | `default` / `featured` variant based on the `featured` flag |
| Pricing Enterprise tile | flat yellow glow shadow | unified gradient ring |
| MCP Capabilities tiles | 1px gray border | unified ring |
| MCP \"Available on GitHub and npm\" promo | gray gradient surface | `solid` variant; tool list chips switched to \`bg-black/40\` with Infima \`code\` styling overridden so the tool name stays \`text-primary-wopee\` and descriptions stay legible inside the solid card |
| MCP \"How it works\" code blocks | Infima light \`pre\` background bleeding through in light theme | \`!bg-transparent\` + \`!text-gray-300\` so the dark code surface renders correctly in both themes |

## Copy

- Hero \"Your application\" placeholder changed from \`Your testing instructions..\` to \`Open homepage, accept cookies if prompted, suggest what to test.\` so first-time visitors get a concrete example prompt.

## Out of scope

- **MCP \"Plug into AI tools\" integration boxes** — kept as neutral thin-border tiles to avoid a busy 6-up gradient grid in a tight row
- **SupportedTestingTools / framework logo cells** — intentionally flat logo grids

## Test plan

- [ ] http://localhost:3000/ — hero (new placeholder copy), benefits 6-up grid, video cards, deployment cards (Cloud \`Recommended\` pill, split title + subtitle, On-Prem outline button, equal heights, no slate bg)
- [ ] http://localhost:3000/pricing/ — Starter / Basic (featured, scaled) / Premium / Enterprise — all share the unified ring
- [ ] http://localhost:3000/mcp/ — Capabilities grid + \"Up and running in 3 minutes\" code blocks (legible in **light** theme!) + \"Available on GitHub and npm\" solid card (tool chips legible in light theme)
- [ ] http://localhost:3000/ai-testing-agents/ and /visual-testing/ — sanity check (reuse shared sections)
- [ ] Light **and** dark theme on each
- [ ] Mobile widths (390×844) and desktop (1440×900)
- [ ] Pricing featured card Ribbon not clipped
- [ ] VideoCard \`#1a1a2e\` inner aligns with the gradient ring