### PR TITLE
fix(home): prevent hero title clipping on short viewports (720–768px)

### DIFF
--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -82,7 +82,7 @@ const HomeHeroVibe = () => {
     setLoginDialogState({ isOpen, mode: "vibe" });
   };
   return (
-    <div className="relative lg:h-[calc(100vh-120px)] flex flex-col justify-center items-center gap-6 lg:gap-8 overflow-hidden py-6 lg:py-8">
+    <div className="relative lg:min-h-[calc(100vh-120px)] flex flex-col justify-center items-center gap-6 lg:gap-8 overflow-hidden py-6 lg:py-8">
       <div
         className="pointer-events-none select-none absolute inset-0 w-full h-full bg-gradient-to-br from-blue-50 via-purple-50 to-indigo-100 dark:from-gray-900 dark:via-purple-900/20 dark:to-indigo-900/20 z-0"
         style={{


### PR DESCRIPTION
## Problem

Users on common laptop screens (1280×720, 1366×768) reported that the hero title "Your app, tested." was clipped at the top and **unreachable by scrolling up**. Scrolling down worked fine, but the first line of the hero title was invisibly chopped off.

Reproduced at 1280×720 on `main` — the first line of the h1 has 31px of its top edge hidden behind the container clip boundary, producing the visual glitch the user reported.

## Root cause

[src/components/home-page/HomeHeroVibe.tsx:85](src/components/home-page/HomeHeroVibe.tsx#L85) combined three things:

1. **Fixed height** — `lg:h-[calc(100vh-120px)]` forced the container to exactly that height
2. **Centered content** — `justify-center` split any overflow evenly to top *and* bottom
3. **Clipped overflow** — `overflow-hidden` hid everything outside those bounds

On any viewport where the hero's natural content (badge + h1 + h2 + form + sample switch + footnote) was taller than `100vh − 120px`, flex centering pushed the top of the content **above** the container's clip boundary. Because the clip happens inside the container (not at the document root), the page's scroll position couldn't reach it.

## Fix

One-character change: `lg:h-[...]` → `lg:min-h-[...]`.

```diff
- <div className="relative lg:h-[calc(100vh-120px)] flex flex-col justify-center items-center gap-6 lg:gap-8 overflow-hidden py-6 lg:py-8">
+ <div className="relative lg:min-h-[calc(100vh-120px)] flex flex-col justify-center items-center gap-6 lg:gap-8 overflow-hidden py-6 lg:py-8">
```

On tall viewports the container still fills `100vh − 120px` and the vertically-centered look is unchanged. On short viewports the container grows to fit its content, so nothing gets clipped and the page scrolls naturally. `overflow-hidden` is kept because it still contains the decorative radial-gradient background.

## Verification

Automated check with Playwright across **the top 20 most-used screen resolutions worldwide** (Statcounter Global Stats + designrush.com, March 2026 — mix of desktop, mobile and tablet). For each viewport the h1's bounding rect is compared against its nearest `overflow: hidden` ancestor; any pixel of the h1 above that clip boundary is a failure.

### Before the fix (`main`)

```
FAIL  desktop-1366x768   h1.top=73.06   clipTop=80   clippedPx=6.94
FAIL  desktop-1280x720   h1.top=49.06   clipTop=80   clippedPx=30.94
... 18 others pass
18/20 passed
```

### After the fix (this PR)

```
20/20 passed
```

## Test plan

- [ ] Resize the browser to ~1280×720 on https://website.wopee.io — the full "Your app, tested. / Autonomously." title should be visible at scroll top.
- [ ] Same check at 1366×768.
- [ ] Taller viewports (1920×1080, 1440×900) still show the hero vertically centered with the same amount of whitespace as before.
- [ ] Hero gradient/grid background is still contained within the hero section (not bleeding into neighbouring sections).
- [ ] Mobile and tablet (portrait/landscape) render unchanged.