### PR TITLE
[website] Shorten site title from 49 to 8 chars to fix 88 long-title warnings

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -7,7 +7,11 @@ const path = require("path");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
-  title: "Wopee.io, the AI Testing Agents for Web Apps",
+  // Site title is appended to every page's <title> tag as "Page Title | <site title>".
+  // Kept short ("Wopee.io") so per-page titles can fit the descriptive context within
+  // Google's ~60-char SERP limit. Per-page Layout `title` props carry the keyword load
+  // (e.g. homepage: "AI Testing Agents for Web Apps").
+  title: "Wopee.io",
   tagline:
     "Boost your testing team. Elevate your quality & speed up release pace.",
   favicon: "img/favicon.png",


### PR DESCRIPTION
Closes autonomous-testing/backlog#3975.

## Summary

Change site title in \`docusaurus.config.js\` from \`"Wopee.io, the AI Testing Agents for Web Apps"\` (49 chars) to \`"Wopee.io"\` (8 chars). Single-line edit + one comment.

## Why this fixes 88 warnings in one line

Docusaurus renders every page's \`<title>\` as \`Page Title | <site title>\`. Today's suffix is \` | Wopee.io, the AI Testing Agents for Web Apps\` — **52 chars before any page-specific text**. Google truncates around 60 chars in SERPs. So virtually any page title pushes past the limit.

Ahrefs flagged **88 of 146 URLs** with \`Title too long\` (May 1 2026 crawl).

After this change the suffix becomes \` | Wopee.io\` (11 chars). Per-page \`title\` props (which already exist on most pages) now have ~50 chars of headroom for the descriptive keyword load.

### Concrete examples

| Page | Current rendered \`<title>\` | After this PR |
|---|---|---|
| Homepage (\`/\`) | \`AI Testing Agents for Web Apps \| Wopee.io, the AI Testing Agents for Web Apps\` (76 chars, **redundant**) | \`AI Testing Agents for Web Apps \| Wopee.io\` (41 chars) |
| \`/visual-testing/\` | \`Visual Regression Testing \| Wopee.io \| Wopee.io, the AI Testing Agents for Web Apps\` (84 chars) | \`Visual Regression Testing \| Wopee.io \| Wopee.io\` (47 chars) |
| \`/about-us/\` | \`About Wopee.io \| AI Testing Agents for Web Apps \| Wopee.io, the AI Testing Agents for Web Apps\` (95 chars) | \`About Wopee.io \| AI Testing Agents for Web Apps \| Wopee.io\` (58 chars) |
| \`/pricing/\` | \`Pricing \| Wopee.io \| Wopee.io, the AI Testing Agents for Web Apps\` (66 chars) | \`Pricing \| Wopee.io \| Wopee.io\` (28 chars) |

(Some pages have \`X | Wopee.io\` baked into their per-page title from when site-title was just \`"Wopee.io"\` historically — that creates the duplicate \`| Wopee.io | Wopee.io\` shown above. Worth a follow-up cleanup but not in this PR; even with the duplicate, length is comfortably under 60.)

## SEO impact analysis — is removing "AI Testing Agents for Web Apps" from the suffix risky?

### What we lose

The phrase "AI Testing Agents for Web Apps" used to appear in **every page's \`<title>\` tag** by virtue of being in the site-title suffix. That's a passive keyword signal across all 146 indexed pages. Specifically we lose:

- **Long-tail keyword coverage** for queries like "ai testing agents", "ai agents for web apps", "testing agents web apps" on pages that don't otherwise mention those phrases
- **Topical-relevance reinforcement** — search engines weight repetition of a brand-defining phrase across a domain

### What we gain (and why the loss is acceptable)

1. **CTR — the bigger lever.** A truncated SERP title (current: \`AI Testing Agents for Web Apps | Wopee.io, the AI Testin...\`) loses the click — even high-ranking pages bleed CTR when titles get cut. Studies put title truncation at 5–15% CTR loss; on a site with ~50 organic signups/month, that compounds.

2. **Targeted, not global, keyword placement.** "AI Testing Agents for Web Apps" already lives in:
   - Homepage \`<title>\` directly (\`Layout title="AI Testing Agents for Web Apps"\`)
   - Homepage H1 (most weight-bearing on-page signal)
   - The dedicated \`/ai-testing-agents/\` landing page (URL slug, H1, body — all stronger than a global title suffix)
   - Most blog posts mention the phrase in body copy

   Pages that need to rank for "ai testing agents" already do so via these direct placements. The global suffix was duplicative for those, and noise for unrelated pages (a blog post about Robot Framework ranking for "ai testing agents" via title suffix is the wrong page anyway).

3. **No brand loss.** "Wopee.io" remains in every \`<title>\` and is the brand search target. Brand-search CTR is unaffected.

4. **Better per-page titling becomes possible.** With 50 chars of headroom, blog posts can have informative titles like "Self-Healing Tests in 2026: How Auto-Repair Cuts Maintenance by 80%" (already exists, currently truncated) — these targeted, descriptive titles outrank a generic global suffix.

### Mitigations if monitoring shows a regression

- **Compromise option** — set site title to \`"Wopee.io · AI Testing"\` (~22 chars). Still 22-char suffix headroom; preserves "AI Testing" keyword globally. Switch is 1 line if needed.
- **Page-level audit** — for any page that mattered for "ai testing" long-tail and now ranks worse, add the phrase to its own \`Layout title\` prop.
- **Monitoring** — check Ahrefs "Pages dropped from Top 10" alert and GSC \`/queries\` 2 weeks post-deploy.

### Net call

The current title is failing both ends: SERP-truncated (CTR loss) AND redundant (the phrase lives in the page title AND the suffix). Shortening keeps the brand, recovers CTR for 88 pages, and doesn't remove the phrase from any page that actually needs it.

## Out of scope (follow-up)

- 6 blog posts with frontmatter \`title:\` already >60 chars on their own (will need individual trims — tracked under #3975 acceptance criteria)
- Cleanup of pages with \`X | Wopee.io\` baked into their per-page \`Layout title\` (creates double-Wopee but not over 60 — cosmetic)

## Test plan

- [ ] Reviewer eyeballs the diff (4 lines)
- [ ] CI: \`docusaurus build\` succeeds
- [ ] Local dev: \`npm start\` and check homepage / a few interior pages — \`<title>\` should now read \`<page name> | Wopee.io\`
- [ ] After merge + deploy: next weekly Ahrefs crawl shows "Title too long" drop from 88 → ≤20

## Source

Ahrefs Site Audit, project Wopee (9266801), May 1 2026 crawl.