### PR TITLE
[website] Add default og:type=website to fix 73 'OG tags incomplete' warnings

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -197,6 +197,9 @@ const config = {
     {
       // Replace with your project's social card
       image: "img/wopee-social-card.jpg",
+      // OG protocol requires og:type. Docusaurus's classic theme doesn't emit a default;
+      // the blog plugin overrides this with og:type=article on blog pages.
+      metadata: [{ property: "og:type", content: "website" }],
       // https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode
       colorMode: {
         defaultMode: "dark",


### PR DESCRIPTION
Closes autonomous-testing/backlog#3976.

## Summary

Add a single default OG meta tag (\`og:type: website\`) via \`themeConfig.metadata\`. Three lines in \`docusaurus.config.js\`.

## Verification (live site)

\`\`\`bash
$ curl -s https://wopee.io/ | grep -oE '<meta [^>]*og:[^>]*>'
<meta property="og:image" ...>
<meta property="og:url" ...>
<meta property="og:locale" ...>
<meta property="og:title" ...>
<meta property="og:description" ...>
# og:type → MISSING
\`\`\`

Same check on \`/pricing/\`, \`/visual-testing/\`, \`/book-demo/\`: all missing \`og:type\`.

\`\`\`bash
$ curl -s https://wopee.io/blog/<post>/ | grep og:type
<meta property="og:type" content="article">   # blog plugin sets this
\`\`\`

The Open Graph Protocol requires \`og:type\`. Docusaurus's classic theme doesn't emit a default — only the blog plugin sets it (\`article\`). All non-blog pages were silently missing it, and Ahrefs flagged them as "Open Graph tags incomplete".

73 flagged URLs ≈ 146 total − 73 blog posts that already have \`og:type=article\`. Math checks out.

## Why this works

\`themeConfig.metadata\` injects meta tags into every page via Docusaurus's react-helmet integration. The blog plugin's per-page \`og:type=article\` is emitted *later* in the render tree, and react-helmet dedupes by \`property\` — later wins. So:

- Marketing/landing/page routes: \`og:type=website\` (this PR)
- Blog routes: \`og:type=article\` (unchanged, blog plugin still wins)

## Test plan

- [ ] CI: \`docusaurus build\` succeeds
- [ ] Local: \`curl localhost:3000/\` shows \`og:type=website\`
- [ ] Local: \`curl localhost:3000/blog/<any-post>/\` still shows \`og:type=article\`
- [ ] After deploy: re-check \`curl https://wopee.io/ | grep og:type\` → \`website\`
- [ ] Next weekly Ahrefs crawl: "OG tags incomplete" drops from 73 → ≤10

## Source

Ahrefs Site Audit, project Wopee (9266801), May 1 2026 crawl. Issue surfaced after the Mar 20 site restructure cleared error-class problems; was previously masked.