### PR TITLE
[website] Fix mixed-content: http://wopee.io → https on /gdpr and /terms links

### DIFF
--- a/src/components/bot-page/CMDLoginForm.tsx
+++ b/src/components/bot-page/CMDLoginForm.tsx
@@ -57,14 +57,14 @@ export const CMDLoginForm = () => {
       <p className="text-xs text-center text-balance">
         By submitting this form you agree to Wopee.io{" "}
         <a
-          href="http://wopee.io/terms-and-conditions"
+          href="https://wopee.io/terms-and-conditions"
           target="_blank"
         >
           Terms and Conditions
         </a>{" "}
         and acknowledge the{" "}
         <a
-          href="http://wopee.io/gdpr"
+          href="https://wopee.io/gdpr"
           target="_blank"
         >
           Privacy Policy

--- a/src/components/home-page/vibe/LoginDialog.tsx
+++ b/src/components/home-page/vibe/LoginDialog.tsx
@@ -93,11 +93,11 @@ const LoginDialog = ({
 
           <p className="text-xs text-center text-balance">
             By submitting this form you agree to Wopee.io{" "}
-            <a href="http://wopee.io/terms-and-conditions" target="_blank">
+            <a href="https://wopee.io/terms-and-conditions" target="_blank">
               Terms and Conditions
             </a>{" "}
             and acknowledge the{" "}
-            <a href="http://wopee.io/gdpr" target="_blank">
+            <a href="https://wopee.io/gdpr" target="_blank">
               Privacy Policy
             </a>
             .


### PR DESCRIPTION
Closes autonomous-testing/backlog#3978 (partially — see "What's not in this PR" below).

## Summary

Two shared components had \`http://\` links to the GDPR and Terms pages, flagging \`/ai-testing-agents/\` (which renders both \`LoginDialog\` and \`CMDLoginForm\`) in Ahrefs as "HTTPS page has internal links to HTTP".

\`\`\`
src/components/home-page/vibe/LoginDialog.tsx    (2 links)
src/components/bot-page/CMDLoginForm.tsx         (2 links)
\`\`\`

4 single-character changes (\`http://\` → \`https://\`).

## #3978 has 3 sub-issues — what's covered

| Sub-issue | URLs (May 1) | This PR |
|---|---|---|
| HTTPS page has internal links to HTTP | 3 | **1 fixed** (the website-repo one) |
| Page has no outgoing links | 1 | See below |
| Duplicate pages without canonical | 2 | See below |

## What's not in this PR

### HTTPS-mixed: 2 URLs are in cmd.wopee.io (CMD app)

The other 2 flagged URLs are \`https://cmd.wopee.io/login?callbackUrl=...\` — those live in the CMD app's repo, not website. Same fix needed there but separate PR scope.

### No outgoing links (1): structural limitation of plugin-client-redirects

\`/blog/top-5-applitools-alternatives-for-visual-testing--2024/\` is a redirect from \`docusaurus.config.js\` → \`/blog/applitools-alternatives\`. \`@docusaurus/plugin-client-redirects\` generates static stub HTML with \`<meta http-equiv="refresh">\` + JS instead of a server-side 301:

\`\`\`bash
$ curl -s https://wopee.io/blog/top-5-applitools-alternatives-for-visual-testing--2024/ | head
<!DOCTYPE html>
<html><head>
  <meta charset="UTF-8">
  <meta http-equiv="refresh" content="0; url=/blog/applitools-alternatives/">
  <link rel="canonical" href="/blog/applitools-alternatives/" />
</head>
<script>
  window.location.href = '/blog/applitools-alternatives/' + window.location.search + window.location.hash;
</script></html>
\`\`\`

Ahrefs sees this as a 200 with no outgoing links (the body is just the meta-refresh tag). Proper fix is a server-side 301 at the CDN/host level — not changeable from this repo's code. Out of scope here.

### Duplicate pages without canonical (0 active)

Live Ahrefs data-explorer shows: \`All filter results: 0\`, \`Lost from filter results: 2\`. The 2 previously-flagged duplicates are no longer flagged — likely resolved by the Mar 20 site restructure removing the duplicates. **No action needed.**

## Test plan

- [ ] CI: \`docusaurus build\` succeeds
- [ ] After deploy: \`curl https://wopee.io/ai-testing-agents/ | grep -E 'http://wopee\\.io'\` → no matches
- [ ] Next weekly Ahrefs crawl: "HTTPS page has internal links to HTTP" drops from 3 to ≤1 (the cmd.wopee.io ones remain until that repo is fixed)

## Source

Ahrefs Site Audit, project Wopee (9266801), May 1 2026 crawl.