### PR TITLE
seo: refresh self-healing & predictive-test-selection — FAQs, JSON-LD, internal links

### DIFF
--- a/blog/2024-07-23-self-healing-in-sw-test-automation/index.md
+++ b/blog/2024-07-23-self-healing-in-sw-test-automation/index.md
@@ -7,6 +7,8 @@ tags: [automation, self-healing, ai, machine-learning, ci-cd, reliability]
 image: ./self-healing-explained.jpg
 ---
 
+import Head from '@docusaurus/Head';
+
 What is self-healing in test automation? It is a mechanism where tests automatically repair broken locators when the application UI changes. When a selector fails, the self-healing engine analyzes the DOM, identifies the intended element using alternative attributes, and updates the test in real time — turning brittle test suites into resilient ones without manual intervention.
 
 <!--truncate-->
@@ -137,7 +139,7 @@ There are numerous tools and frameworks offering self-healing capabilities in te
 
 ### 1. Selenium with Self-Healing Extensions
 
-Selenium, a popular open-source testing framework, can be enhanced with self-healing capabilities through various libraries and plugins like Selenium IDE (Google Chrome extension) or healenium.io. These extensions integrate with existing Selenium test suites, offering flexibility and customization.
+Selenium, a popular open-source testing framework, can be enhanced with self-healing capabilities through various libraries and plugins like Selenium IDE (Google Chrome extension) or healenium.io. These extensions integrate with existing Selenium test suites, offering flexibility and customization. Playwright and Cypress users typically reach for AI-driven layers instead — for Playwright, our [Playwright Bot](/blog/playwright-bot-ai-powered-test-automation/) regenerates failing locators on the fly so you do not maintain selectors manually.
 
 ### 2. Testim
 
@@ -294,6 +296,7 @@ The future of self-healing test automation will likely see:
 - Development of unified frameworks that combine self-healing, AI, and other advanced testing methodologies into cohesive solutions
 - Deeper integration with CI/CD pipelines, allowing for real-time healing and feedback within development workflows
 - Automated rollback and recovery mechanisms that can handle test failures and ensure stability in production environments
+- Standardized agent-to-agent test orchestration via the [Model Context Protocol (MCP)](/mcp/), so healing decisions are auditable across tools
 
 ### 4. Intelligent Test Case Generation
 
@@ -319,6 +322,103 @@ To stay competitive in the rapidly changing landscape of software development, i
 
 As you embark on your journey with self-healing test automation, remember that it's not just about adopting new tools or technologies. It's about fostering a culture of continuous improvement, staying informed about emerging trends, and always striving to optimize your testing processes. With the right approach and a commitment to innovation, self-healing test automation can be a significant improvement of stability for your software quality assurance efforts.
 
+## FAQ
+
+### What is self-healing in test automation?
+
+Self-healing in test automation is the ability of a test framework to detect a broken locator at runtime and repair it without human intervention. When a selector fails, the engine inspects the current DOM, finds the most likely intended element using alternative attributes, accessibility roles, or visual cues, and continues the test. The repaired locator is then logged or persisted so the suite stays green across UI changes.
+
+### How does a self-healing engine actually work?
+
+A self-healing engine builds a snapshot of each element it interacts with — id, classes, text, ARIA role, position, neighbors, and sometimes a visual fingerprint. On a later run, if the primary locator misses, the engine scores every candidate element against that snapshot and picks the best match above a confidence threshold. Lower-confidence matches are flagged for review, so you keep an audit trail instead of silent passes.
+
+### Which frameworks support self-healing — Playwright, Cypress, Selenium?
+
+All three can run self-healing, but the ergonomics differ. Selenium has the longest tooling history (Healenium, Testim, Katalon, Ranorex). Cypress relies on plugins or commercial layers on top of its retry-ability model. Playwright pairs well with AI-driven layers like our [Playwright Bot](/blog/playwright-bot-ai-powered-test-automation/), which regenerates locators on the fly using an LLM rather than a fixed locator-fallback list.
+
+### How is self-healing different from "AI healing" or "auto-healing"?
+
+The terms overlap heavily in marketing, but there is a useful split. Classic self-healing uses deterministic fallback rules and similarity scoring. "AI healing" or "auto-healing" usually means an LLM or vision model proposes a new locator from natural-language intent ("the Submit button"), which is more robust to large refactors but needs guardrails to avoid clicking the wrong element. Most modern platforms blend both.
+
+### Does self-healing replace manual test maintenance?
+
+No, and you should be skeptical of any vendor that says it does. Self-healing eliminates the busywork of fixing locators after cosmetic UI changes — that is the bulk of flaky-test maintenance, but it is not all of it. Logic changes, new flows, and removed features still need human authoring. Treat self-healing as the safety net that lets your team focus on tests that actually exercise new behaviour.
+
+### How much test maintenance can self-healing realistically eliminate?
+
+Teams that adopt mature self-healing report 60-80% reductions in locator-related maintenance, with the variance driven mostly by how disciplined their original selectors were. Suites built on stable test ids see smaller gains; suites built on brittle XPaths see the largest. Pair self-healing with [predictive test selection](/blog/predictive-test-selection/) and you compound the win — fewer flaky failures and fewer tests to run per change.
+
+### Should self-healing fix locators silently or require approval?
+
+For long-lived suites, require approval on low-confidence repairs and auto-apply only on high-confidence matches. Silent healing on every failure is how you end up with a green pipeline that no longer tests what you think it does. Most platforms expose this as a confidence threshold plus a review queue — set it deliberately rather than accepting the default.
+
+<Head>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is self-healing in test automation?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Self-healing in test automation is the ability of a test framework to detect a broken locator at runtime and repair it without human intervention. When a selector fails, the engine inspects the current DOM, finds the most likely intended element using alternative attributes, accessibility roles, or visual cues, and continues the test. The repaired locator is then logged or persisted so the suite stays green across UI changes."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does a self-healing engine actually work?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "A self-healing engine builds a snapshot of each element it interacts with — id, classes, text, ARIA role, position, neighbors, and sometimes a visual fingerprint. On a later run, if the primary locator misses, the engine scores every candidate element against that snapshot and picks the best match above a confidence threshold. Lower-confidence matches are flagged for review, so you keep an audit trail instead of silent passes."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Which frameworks support self-healing — Playwright, Cypress, Selenium?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "All three can run self-healing, but the ergonomics differ. Selenium has the longest tooling history (Healenium, Testim, Katalon, Ranorex). Cypress relies on plugins or commercial layers on top of its retry-ability model. Playwright pairs well with AI-driven layers like Wopee.io's Playwright Bot, which regenerates locators on the fly using an LLM rather than a fixed locator-fallback list."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How is self-healing different from \"AI healing\" or \"auto-healing\"?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The terms overlap heavily in marketing, but there is a useful split. Classic self-healing uses deterministic fallback rules and similarity scoring. \"AI healing\" or \"auto-healing\" usually means an LLM or vision model proposes a new locator from natural-language intent (\"the Submit button\"), which is more robust to large refactors but needs guardrails to avoid clicking the wrong element. Most modern platforms blend both."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Does self-healing replace manual test maintenance?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "No, and you should be skeptical of any vendor that says it does. Self-healing eliminates the busywork of fixing locators after cosmetic UI changes — that is the bulk of flaky-test maintenance, but it is not all of it. Logic changes, new flows, and removed features still need human authoring. Treat self-healing as the safety net that lets your team focus on tests that actually exercise new behaviour."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How much test maintenance can self-healing realistically eliminate?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Teams that adopt mature self-healing report 60-80% reductions in locator-related maintenance, with the variance driven mostly by how disciplined their original selectors were. Suites built on stable test ids see smaller gains; suites built on brittle XPaths see the largest. Pair self-healing with predictive test selection and you compound the win — fewer flaky failures and fewer tests to run per change."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Should self-healing fix locators silently or require approval?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "For long-lived suites, require approval on low-confidence repairs and auto-apply only on high-confidence matches. Silent healing on every failure is how you end up with a green pipeline that no longer tests what you think it does. Most platforms expose this as a confidence threshold plus a review queue — set it deliberately rather than accepting the default."
+          }
+        }
+      ]
+    })}
+  </script>
+</Head>
+
 ### Take Your Testing to the Next Level with Us!
 
 Are you ready to revolutionize your testing processes and dramatically improve your software quality? We're passionate about helping organizations like yours harness the power of self-healing test automation. Our team of expert consultants has deep experience in implementing cutting-edge testing solutions across various industries.
@@ -330,7 +430,7 @@ Don't let unstable tests and constant maintenance slow down your development cyc
 - Train your team on best practices and emerging trends in test automation
 - Provide ongoing support and optimization to ensure your testing processes stay ahead of the curve
 
-We'd love to help you unlock its benefits for your organization. Whether you're just starting your automation journey or looking to enhance your existing processes, we have the expertise to guide you every step of the way.
+If you want to skip the build phase, our [AI testing agents](/ai-testing-agents/) ship self-healing out of the box — see [pricing](/pricing/) for plan details. We'd love to help you unlock its benefits for your organization. Whether you're just starting your automation journey or looking to enhance your existing processes, we have the expertise to guide you every step of the way.
 
 Contact us for a consultation and discover how we can help you achieve unprecedented levels of testing efficiency and software quality. Let's work together to build a more robust, reliable, and agile testing ecosystem for your organization.
 

--- a/blog/2024-08-02-BDD-w-Robot-Framework/index.md
+++ b/blog/2024-08-02-BDD-w-Robot-Framework/index.md
@@ -249,10 +249,10 @@ Scenario: User creates a new playlist
 
 To enhance your BDD implementation in Robot Framework, consider the following tips:
 
-1. **Reuse Keywords**: Create reusable keywords for common actions, such as logging in or navigating to a specific page. This reduces duplication and makes your test cases easier to maintain.
+1. **Reuse Keywords**: Create reusable keywords for common actions, such as logging in or navigating to a specific page. This reduces duplication and makes your test cases easier to maintain — and pairs well with [self-healing test automation](/blog/self-healing-in-sw-test-automation/), which keeps those keywords stable when the UI shifts underneath them.
 2. **Data-Driven Testing**: Use data-driven tests to run the same scenario with different sets of data. This can be achieved using the `Examples` section in Gherkin or by defining variables in Robot Framework.
 3. **Organize Tests**: Structure your tests in a way that makes them easy to understand and navigate. Use meaningful names for test cases and keywords, and group related tests into suites.
-4. **Continuous Integration**: Integrate your Robot Framework tests into a continuous integration (CI) pipeline. This ensures that your tests are run automatically whenever changes are made, providing immediate feedback on the quality of your software.
+4. **Continuous Integration**: Integrate your Robot Framework tests into a continuous integration (CI) pipeline. This ensures that your tests are run automatically whenever changes are made, providing immediate feedback on the quality of your software. Once the suite grows past the point where everyone waits for it, layer [predictive test selection](/blog/predictive-test-selection/) on top so each pull request runs only the highest-risk subset.
 
 ### Example of Data-Driven Test in BDD
 
@@ -273,7 +273,7 @@ Feature: Login Functionality
 
 ## Conclusion
 
-Getting started with BDD in Robot Framework is a powerful way to align development efforts with business goals. By following a structured process and leveraging the collaborative nature of BDD, teams can build software that truly meets user needs while maintaining high quality through automated testing. Whether you're new to BDD or looking to refine your practices, Robot Framework offers the tools you need to succeed. Embrace techniques like Example Mapping and explore alternative approaches to continuously improve your BDD implementation.
+Getting started with BDD in Robot Framework is a powerful way to align development efforts with business goals. By following a structured process and leveraging the collaborative nature of BDD, teams can build software that truly meets user needs while maintaining high quality through automated testing — and as the suite matures, techniques like [self-healing](/blog/self-healing-in-sw-test-automation/) and [predictive test selection](/blog/predictive-test-selection/) keep the maintenance bill from outpacing the value. Whether you're new to BDD or looking to refine your practices, Robot Framework offers the tools you need to succeed. Embrace techniques like Example Mapping and explore alternative approaches to continuously improve your BDD implementation.
 
 :::tip **Next Steps 🚀**
 

--- a/blog/2024-08-12-predictive-test-selection/index.md
+++ b/blog/2024-08-12-predictive-test-selection/index.md
@@ -13,6 +13,8 @@ tags:
 image: ./test-selection.jpg
 ---
 
+import Head from '@docusaurus/Head';
+
 Predictive test selection uses machine learning to decide which tests to run for each code change. It works by analyzing commit history, code coverage data, and past failure patterns to rank tests by risk. High-risk tests run first, low-risk tests are deferred or skipped — giving teams faster CI feedback while maintaining defect coverage across releases.
 
 <!--truncate-->
@@ -147,7 +149,7 @@ Auto Test Pilot is a tool that automates the prioritization of tests based on a 
 
 ### The Challenge of Integration
 
-While these tools offer powerful predictive test selection capabilities, it's important to note that they are typically additional components that need to be added to your existing test automation toolset. They do not directly integrate into traditional test automation tools such as Selenium, Cypress.io, or API testing tools like Postman or Insomnia. Instead, they provide complementary functionalities that enhance the capabilities of these tools by offering intelligent test selection and prioritization. This additional layer can lead to significant efficiency gains, though it may require extra management of infrastructure and processes.
+While these tools offer powerful predictive test selection capabilities, it's important to note that they are typically additional components that need to be added to your existing test automation toolset. They do not directly integrate into traditional test automation tools such as Selenium, Cypress.io, or API testing tools like Postman or Insomnia. Instead, they provide complementary functionalities that enhance the capabilities of these tools by offering intelligent test selection and prioritization. This additional layer can lead to significant efficiency gains, though it may require extra management of infrastructure and processes. Newer agent-based platforms expose the same prioritization signals over the [Model Context Protocol (MCP)](/mcp/), which makes the selection decisions readable by any orchestration tool you already run.
 
 :::info Links to the Tools Mentioned above
 
@@ -203,6 +205,103 @@ KEY TAKEAWAYS
 - Tools like Launchable, TestBrain, Sealights, and Auto Test Pilot provide predictive test selection capabilities to enhance existing test automation workflows.
 - Intelligent test execution involves dynamically determining when and what to test based on various factors, such as code changes and development goals.
 - The future of PTS in test automation promises even greater accuracy, efficiency, and integration within CI/CD pipelines, making it an essential component of modern testing strategies.
+
+## FAQ
+
+### What is predictive test selection?
+
+Predictive test selection (PTS) is a CI optimization technique that uses machine learning to choose which tests to run for a given code change. Instead of running the entire suite, the model ranks tests by their probability of catching a regression based on the files touched, recent failure history, and code coverage data. Teams keep nightly or release runs as a full safety net and use PTS for fast feedback on every commit or pull request.
+
+### How does the AI rank which tests to run?
+
+The model is trained on your CI history: which tests failed, which files those tests covered, and which commits introduced the failures. For each new change it scores every test on expected fault-finding value, then sorts the queue from most to least informative. Most production tools combine this with a budget — "give me the smallest set of tests that catches 99% of historical regressions for this change" — so the output is a ranked, capped subset rather than a binary include/exclude.
+
+### How does predictive test selection integrate with CI/CD pipelines?
+
+Integration is usually a thin layer in front of your existing runner. The PTS service receives the changed-files list and git context, returns a ranked test list, and your pipeline executes that subset (Jenkins, GitHub Actions, GitLab CI, CircleCI all work). After the run, results are streamed back so the model can keep learning. The trickier part is data hygiene: you need stable test names and a clean failure-attribution signal, otherwise the model learns from noise.
+
+### What is the false-negative risk — can PTS skip a test that would have caught a bug?
+
+Yes, and pretending otherwise is the fastest way to lose trust in the system. Mature deployments accept a small, measured false-negative rate on every-commit runs and offset it with a full regression run on a slower cadence (nightly, pre-release). Track the rate explicitly and tune the selection budget so the recall stays above your team's tolerance — typically 95-99% — rather than chasing the smallest possible test set.
+
+### How is predictive test selection different from test impact analysis?
+
+Test impact analysis (TIA) is deterministic: it maps code coverage to tests and runs every test that touches a changed file. PTS is probabilistic: it ranks tests by likelihood of failure, which catches cross-file dependencies that pure coverage misses (e.g. config changes, flaky areas, recently broken modules). In practice the two compose well — start with TIA to bound the candidate set, then use PTS to rank and cap it.
+
+### Which tools support predictive test selection?
+
+Launchable, Appsurify TestBrain, Sealights, and Orangebeard's Auto Test Pilot are the dedicated PTS vendors covered above. Bazel-based monorepos at Google, Meta, and Uber run in-house variants. For teams already on AI-driven test platforms, prioritization is increasingly a feature rather than a separate product — Wopee.io's [AI testing agents](/ai-testing-agents/) include risk-based execution alongside [self-healing](/blog/self-healing-in-sw-test-automation/), so you do not run two separate services.
+
+### When does predictive test selection actually pay off?
+
+PTS earns its keep when your full suite takes long enough that engineers wait for it (15+ minutes is the rough threshold) and your CI bill is non-trivial. Below that, the integration cost rarely beats just running everything. Above that, payback is usually weeks: see [pricing](/pricing/) for what a managed setup looks like, or build it in-house if you have the data engineering capacity to keep the model honest.
+
+<Head>
+  <script type="application/ld+json">
+    {JSON.stringify({
+      "@context": "https://schema.org",
+      "@type": "FAQPage",
+      "mainEntity": [
+        {
+          "@type": "Question",
+          "name": "What is predictive test selection?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Predictive test selection (PTS) is a CI optimization technique that uses machine learning to choose which tests to run for a given code change. Instead of running the entire suite, the model ranks tests by their probability of catching a regression based on the files touched, recent failure history, and code coverage data. Teams keep nightly or release runs as a full safety net and use PTS for fast feedback on every commit or pull request."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does the AI rank which tests to run?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "The model is trained on your CI history: which tests failed, which files those tests covered, and which commits introduced the failures. For each new change it scores every test on expected fault-finding value, then sorts the queue from most to least informative. Most production tools combine this with a budget — \"give me the smallest set of tests that catches 99% of historical regressions for this change\" — so the output is a ranked, capped subset rather than a binary include/exclude."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How does predictive test selection integrate with CI/CD pipelines?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Integration is usually a thin layer in front of your existing runner. The PTS service receives the changed-files list and git context, returns a ranked test list, and your pipeline executes that subset (Jenkins, GitHub Actions, GitLab CI, CircleCI all work). After the run, results are streamed back so the model can keep learning. The trickier part is data hygiene: you need stable test names and a clean failure-attribution signal, otherwise the model learns from noise."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "What is the false-negative risk — can PTS skip a test that would have caught a bug?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Yes, and pretending otherwise is the fastest way to lose trust in the system. Mature deployments accept a small, measured false-negative rate on every-commit runs and offset it with a full regression run on a slower cadence (nightly, pre-release). Track the rate explicitly and tune the selection budget so the recall stays above your team's tolerance — typically 95-99% — rather than chasing the smallest possible test set."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "How is predictive test selection different from test impact analysis?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Test impact analysis (TIA) is deterministic: it maps code coverage to tests and runs every test that touches a changed file. PTS is probabilistic: it ranks tests by likelihood of failure, which catches cross-file dependencies that pure coverage misses (e.g. config changes, flaky areas, recently broken modules). In practice the two compose well — start with TIA to bound the candidate set, then use PTS to rank and cap it."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "Which tools support predictive test selection?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "Launchable, Appsurify TestBrain, Sealights, and Orangebeard's Auto Test Pilot are the dedicated PTS vendors. Bazel-based monorepos at Google, Meta, and Uber run in-house variants. For teams already on AI-driven test platforms, prioritization is increasingly a feature rather than a separate product — Wopee.io's AI testing agents include risk-based execution alongside self-healing, so you do not run two separate services."
+          }
+        },
+        {
+          "@type": "Question",
+          "name": "When does predictive test selection actually pay off?",
+          "acceptedAnswer": {
+            "@type": "Answer",
+            "text": "PTS earns its keep when your full suite takes long enough that engineers wait for it (15+ minutes is the rough threshold) and your CI bill is non-trivial. Below that, the integration cost rarely beats just running everything. Above that, payback is usually weeks for a managed setup, or longer if you build it in-house and need data engineering capacity to keep the model honest."
+          }
+        }
+      ]
+    })}
+  </script>
+</Head>
 
 :::tip Innovate with us
 


### PR DESCRIPTION
## Summary

Refreshes two high-impression / page-2 blog posts to capture People-Also-Ask SERP slots and become eligible for FAQ rich snippets / AI Overview inclusion. 8-week Google Search Console data:

- `self-healing-in-sw-test-automation` — 7,130 impressions, 10 clicks, **0.14% CTR, pos 12.6**.
- `predictive-test-selection` — 6,649 impressions, 31 clicks, 0.47% CTR, **pos 6.6**.

That is ~14k impressions per 8 weeks stuck on page 2. The titles and meta descriptions were already 2026-framed and CTR-optimized, so this PR keeps them as-is and instead fills the gaps that were holding ranking back: no FAQ section, no structured data, and weak internal-link equity.

## What changed

### `blog/2024-07-23-self-healing-in-sw-test-automation/index.md`

- New `## FAQ` section (7 PAA-style questions): what is self-healing, how the engine works, framework support (Playwright/Cypress/Selenium), self-healing vs "AI healing"/"auto-healing", whether it replaces manual maintenance, realistic maintenance reduction, silent vs reviewed fixes. Answers are 2-4 sentences, answer-first, LLM-friendly.
- `FAQPage` JSON-LD via `@docusaurus/Head` with `JSON.stringify` (mirrors the pattern already used in `src/pages/about-us/index.tsx`). Question text matches the visible FAQ verbatim.
- 3 new contextual internal links woven into existing paragraphs: `/blog/playwright-bot-ai-powered-test-automation/` (Playwright self-healing context), `/mcp/` (future trends bullet), `/pricing/` + `/ai-testing-agents/` reframed in the closing CTA.

### `blog/2024-08-12-predictive-test-selection/index.md`

- New `## FAQ` section (7 PAA-style questions): definition, how the AI ranks tests, CI/CD integration, false-negative risk, predictive vs test-impact-analysis, which tools support it, ROI threshold.
- Matching `FAQPage` JSON-LD via `@docusaurus/Head`.
- 3 new contextual links: `/mcp/` (in the integration section), `/blog/self-healing-in-sw-test-automation/` (FAQ on tool overlap), `/ai-testing-agents/` and `/pricing/` (FAQ on ROI).

### `blog/2024-08-02-BDD-w-Robot-Framework/index.md`

This post ranks 1.54% CTR / pos 9.7 — strongest in the blog cluster — so it is the cleanest source of internal-link equity. Added 3 contextual paragraph-level links to the two refreshed posts (within "Reuse Keywords", "Continuous Integration", and the conclusion). No "Related posts" list, no new sections — only sentence-level edits.

## Why these changes (not a title rewrite)

Title and description on both posts already do the keyword work. The posts lost on SERP because:
1. No FAQ block → no PAA capture, no AI Overview inclusion.
2. No structured data → no rich snippets.
3. Thin internal-link equity from the strongest-ranking blog (BDD/Robot Framework).

This PR fixes all three without touching prose voice or replacing copy that is already working.

## Test plan

- [x] `yarn build` passes (Docusaurus 3.9.2, no new errors, no new broken links/anchors)
- [x] `FAQPage` JSON-LD present in built HTML for both posts (`grep FAQPage build/blog/.../index.html`)
- [ ] Validate JSON-LD in https://validator.schema.org/ after deploy
- [ ] Validate JSON-LD in https://search.google.com/test/rich-results after deploy
- [ ] Re-check GSC after 4-6 weeks for CTR + position movement on both posts

## Notes

- One preexisting markdown-lint warning (MD029 on the BDD post, line 209) is unrelated to this PR — it was already present on `main`.
- One preexisting broken-anchor warning (`/blog/applitools-alternatives/`) is unrelated and surfaced during the build verification only.