### PR TITLE
feat(seo): llms.txt + JSON-LD + TL;DR FAQ openers for LLM visibility

### DIFF
--- a/blog/2024-05-08-getting-started-w-playwright-visual-testing/index.md
+++ b/blog/2024-05-08-getting-started-w-playwright-visual-testing/index.md
@@ -7,9 +7,66 @@ tags: [basics, testing-tools, playwright, test-automation, visual-testing]
 image: ./intro-to-pw-visual-testing.png
 ---
 
+Playwright supports visual testing out of the box: install Playwright, write a test that calls `expect(page).toHaveScreenshot()`, run it once to create a baseline, then run it on every CI build to catch visual regressions. Baselines live in your repo, comparisons are pixel-based with a configurable threshold, and the whole workflow plugs into the same test runner you already use for functional tests. This guide walks through install, first screenshot test, baseline management, and CI wiring with the current Playwright API.
+
 [Visual testing](/visual-testing/) has become an essential component of modern web development. By ensuring the visual fidelity of your application across different browsers and devices, you can guarantee a seamless user experience and minimize the risk of regressions. However, visual testing can be cumbersome, time-consuming, and require significant maintenance when it is not done properly. This is where Playwright could offer an efficient, fast, and simple approach to visual testing.
 
 <!--truncate-->
+
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "Does Playwright support visual testing out of the box?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Playwright ships with toHaveScreenshot() assertions that capture screenshots, store baselines in your repo, and compare against them on every run. No separate visual testing tool is required to get started."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I write my first Playwright visual test?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Install Playwright with npm init playwright@latest, navigate to the page you want to test in a test file, and call await expect(page).toHaveScreenshot(). The first run creates a baseline image; subsequent runs compare against it and fail on visual differences."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does Playwright compare screenshots?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Playwright performs pixel-by-pixel comparison with a configurable maxDiffPixels and threshold value. You can also mask dynamic regions (timestamps, ads, animated elements) to keep tests stable across runs."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where are Playwright visual baselines stored?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Baseline screenshots are committed to your repo next to the test files, organized by browser and platform. When you intentionally change the UI, you regenerate baselines with the --update-snapshots flag."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How do I integrate Playwright visual tests into CI?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Run npx playwright test in your CI pipeline like any other Playwright run. To avoid environment-specific rendering differences, pin the OS and browser version (use the official Playwright Docker image is the safest path) and treat baseline regeneration as a deliberate PR step."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What are the limits of Playwright visual testing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Pixel-based comparisons can be brittle on dynamic content, fonts, and rendering differences across machines. For larger suites, AI-powered visual testing tools that ignore irrelevant changes and self-heal on layout shifts (such as Wopee.io) reduce maintenance significantly."
+      }
+    }
+  ]
+}) }} />
 
 ![Getting Started with Playwright Visual Testing](./intro-to-pw-visual-testing.png)
 _Source: Wopee.io internal materials._

--- a/blog/2024-09-12-playwright-bot/index.md
+++ b/blog/2024-09-12-playwright-bot/index.md
@@ -7,11 +7,68 @@ tags: [playwright, automation, testing, AI]
 image: ./pw-bot.png
 ---
 
+Playwright Bot is an AI agent that generates, runs, and maintains Playwright tests from a URL — no manual scripting required. It collects HTML and screenshots, uses an LLM to derive user flows, and emits adaptive Playwright code that handles cookie banners and shifting UI. Compared to Playwright codegen, which only records what you click, Playwright Bot decides what to test and rewrites scripts when your app changes.
+
+<!--truncate-->
+
 > ## Automating tests isn’t a luxury anymore. It’s a necessity.
 
 But here’s the catch: manual test creation is frustratingly slow, error-prone, and simply doesn’t scale for modern, rapidly evolving web applications.
 
-<!--truncate-->
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is Playwright Bot?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Playwright Bot is an AI agent built on top of Playwright that generates end-to-end test cases automatically from a URL. It collects HTML and screenshots, uses a large language model to derive user flows, and outputs runnable Playwright test code without manual scripting."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How is Playwright Bot different from Playwright codegen?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Playwright codegen records the actions you perform manually in a browser. Playwright Bot decides what to test on its own — it explores the app, identifies meaningful user flows, and generates assertions, then keeps tests up to date as the UI changes."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do I need to write any code to use Playwright Bot?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No. You point the bot at a URL and it generates Playwright test cases on its own. You can review and tweak the emitted code, but writing tests from scratch is not required."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Playwright Bot handle cookie banners and dynamic content?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Playwright Bot detects common patterns like cookie consent dialogs and dynamic widgets and handles them in the generated tests, so you do not need to special-case them by hand."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Does Playwright Bot self-heal tests when the UI changes?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. When a selector or flow breaks because of UI changes, Playwright Bot re-analyzes the page and updates the test rather than failing it outright, which is the main reason it scales beyond hand-written suites."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is Playwright Bot free to try?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. You can try Playwright Bot for free through Wopee.io — no credit card required. There is also an open Playwright AI Bot demo repository on GitHub."
+      }
+    }
+  ]
+}) }} />
 
 Playwright Bot changes that. It doesn’t just run your tests—it _creates_ them for you. Automatically. Using AI (LLMs). It’s part of a broader wave of [AI-powered testing agents](/ai-testing-agents/) transforming how teams approach quality. Forget about writing endless scripts or hunting down bugs caused by unstable locators. Playwright Bot does the heavy lifting so you don’t have to.
 

--- a/blog/2024-09-25-top-5-applitools-alternatives-for-visual-testing/index.md
+++ b/blog/2024-09-25-top-5-applitools-alternatives-for-visual-testing/index.md
@@ -15,6 +15,61 @@ We’ve compared the top 5 Applitools competitors based on features, use cases, 
 
 <!--truncate-->
 
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What are the best Applitools alternatives for visual testing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The five strongest Applitools alternatives in 2026 are Wopee.io, Percy (BrowserStack), LambdaTest, Chromatic, and BackstopJS. They cover the spectrum from free open-source visual diffing (BackstopJS) to AI-powered autonomous testing platforms (Wopee.io)."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Why do teams switch away from Applitools?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The most common reasons are pricing (Applitools plans are often prohibitive for small and mid-sized teams), setup and maintenance complexity, and difficulty handling dynamic content. Teams want a tool that is easier to onboard and cheaper to scale."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Is there a free Applitools alternative?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. BackstopJS is fully open source and free. Wopee.io and Percy offer free tiers you can start with without a credit card. Chromatic has a free plan tied to Storybook usage."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which Applitools alternative is best for AI-powered visual testing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Wopee.io. It combines AI-powered visual regression with autonomous test generation and self-healing, so when your UI changes the tests adapt automatically rather than flagging every diff as a regression."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Which Applitools alternative integrates with Playwright?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Wopee.io and Percy both integrate cleanly with Playwright. Wopee.io can also generate Playwright tests for you, so your visual checks live next to your functional tests in the same runner."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How does Wopee.io compare to Applitools on pricing?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Wopee.io starts free with no credit card and paid plans begin at €19/user/month. Applitools' published plans start considerably higher and typically require an annual commitment for any meaningful usage."
+      }
+    }
+  ]
+}) }} />
+
 ## Introduction
 
 Are you frustrated with the high costs and complexity of Applitools? You're not alone. Many QA teams are searching for simpler, more affordable alternatives to streamline their visual regression testing. While Applitools is a widely recognized tool, its steep learning curve, costly plans, and challenging maintenance make it a less-than-ideal option for many teams, especially those with limited resources.

--- a/blog/2024-12-19-ai-testing-agents/index.md
+++ b/blog/2024-12-19-ai-testing-agents/index.md
@@ -7,6 +7,8 @@ tags: [testing, automation, AI]
 image: ./ai-testing-agents.webp
 ---
 
+AI testing agents are autonomous software programs that explore a web app, generate test cases, execute them, and adapt when the UI changes — without human-written scripts. In 2026, the parts that actually work are autonomous test generation from a URL, self-healing of broken selectors, and visual regression with smart filtering. The parts that are still hype are full end-to-end QA replacement, reliable root-cause diagnosis, and testing complex multi-step business logic without human supervision. Start by replacing the most brittle, repetitive parts of your suite — not the whole thing.
+
 > ## Revolution or Just Another Tech Hype?
 
 I’ve seen this before: test automation was supposed to kill testing, then autonomous testing came to bury it further. Now, AI Testing Agents claim to be the ultimate disruptors.
@@ -21,6 +23,61 @@ Curious? Let’s dive in and uncover whether AI Testing Agents.
 _Image Source: Generated using DALL·E by OpenAI.._
 
 <!--truncate-->
+
+<script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify({
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+    {
+      "@type": "Question",
+      "name": "What is an AI testing agent?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "An AI testing agent is an autonomous software program that explores a web application, derives user flows, generates test cases, executes them in a real browser, and adapts when the UI changes — all without a human writing test scripts. It combines a large language model with browser automation."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How are AI testing agents different from traditional test automation?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Traditional test automation runs the scripts a human wrote. AI testing agents decide what to test, write the scripts, and rewrite them when the UI changes. The shift is from execution-only automation to autonomous test creation and maintenance."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What can AI testing agents do today, in 2026?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Reliably: autonomous test generation from a URL, self-healing of broken locators, visual regression testing with smart filtering, and natural-language test authoring. Less reliably: testing complex multi-step business logic, diagnosing root causes, and replacing senior QA judgement."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Will AI testing agents replace QA engineers?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No, not in 2026. They take over the most repetitive and brittle parts of QA — generating regression coverage, maintaining selectors, running visual checks — but exploratory testing, test strategy, and judgement on what is acceptable still need humans."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Where should a team start with AI testing agents?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Start narrow: pick the most brittle or most-skipped part of your existing test suite (typically visual regression or login/checkout regression) and let an AI agent cover that. Expand only after you trust the results in CI."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Do AI testing agents work with Playwright?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes. Tools like Wopee.io's Playwright Bot generate runnable Playwright code, so the output integrates with your existing Playwright runner, fixtures, and CI pipeline. You keep Playwright as the execution layer and let the agent handle authoring and maintenance."
+      }
+    }
+  ]
+}) }} />
 
 ## What Are AI Agents?
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,12 +13,62 @@ import HomeDeploymentOptions from "@/components/home-page/HomeDeploymentOptions"
 import HomeEndingSection from "@/components/home-page/HomeEndingSection";
 import HomeFaqSection from "@/components/home-page/HomeFaqSection";
 
+const JSONLD_ORG = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: "Wopee.io",
+  legalName: "wopee labs s.r.o.",
+  url: "https://wopee.io",
+  logo: "https://wopee.io/img/logo.png",
+  email: "help@wopee.io",
+  sameAs: [
+    "https://www.linkedin.com/company/wopee",
+    "https://github.com/Wopee-io",
+    "https://www.youtube.com/@wopee",
+  ],
+  contactPoint: {
+    "@type": "ContactPoint",
+    email: "help@wopee.io",
+    contactType: "customer support",
+    availableLanguage: ["English"],
+  },
+};
+
+const JSONLD_APP = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Wopee.io",
+  applicationCategory: "DeveloperApplication",
+  applicationSubCategory: "Test Automation",
+  operatingSystem: "Web",
+  url: "https://wopee.io",
+  description:
+    "Autonomous AI testing agents for web applications. Wopee.io agents explore your app, generate Playwright tests, run them across browsers, and self-heal when the UI changes.",
+  publisher: {
+    "@type": "Organization",
+    name: "Wopee.io",
+    url: "https://wopee.io",
+  },
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "EUR",
+    description:
+      "Free to start, no credit card required. Paid plans from €19/user/mo.",
+    url: "https://wopee.io/pricing/",
+  },
+};
+
 export default function Home(): JSX.Element {
   return (
     <Layout
       title="AI Testing Agents for Web Apps"
       description="Stop writing tests manually. Wopee.io AI agents explore your app, generate Playwright tests, and self-heal when your UI changes. Try free."
     >
+      <Head>
+        <script type="application/ld+json">{JSON.stringify(JSONLD_ORG)}</script>
+        <script type="application/ld+json">{JSON.stringify(JSONLD_APP)}</script>
+      </Head>
       <HomeHeroVibe />
       <HomeTrustedBy />
       <HomeBenefits />

--- a/src/pages/mcp/index.tsx
+++ b/src/pages/mcp/index.tsx
@@ -13,6 +13,7 @@ import {
 import Icon from "@mdi/react";
 import React, { useState, useEffect } from "react";
 import Link from "@docusaurus/Link";
+import Head from "@docusaurus/Head";
 
 import Layout from "@theme/Layout";
 import ButtonPrimary from "@site/src/components/buttons/ButtonPrimary";
@@ -555,12 +556,65 @@ const OpenSourceSection = () => (
   </div>
 );
 
+const JSONLD_MCP_APP = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Wopee.io MCP Server",
+  applicationCategory: "DeveloperApplication",
+  applicationSubCategory: "Test Automation",
+  operatingSystem: "Cross-platform (Node.js 18+)",
+  url: "https://wopee.io/mcp/",
+  description:
+    "Model Context Protocol server that connects Claude Code, Claude Desktop, Cursor, VS Code, Windsurf, and other MCP clients to Wopee.io. Dispatch autonomous testing agents, generate test artifacts, fetch execution results, and manage test suites from natural-language conversation.",
+  softwareRequirements: "Node.js 18+",
+  downloadUrl: "https://www.npmjs.com/package/wopee-mcp",
+  installUrl: "https://www.npmjs.com/package/wopee-mcp",
+  publisher: {
+    "@type": "Organization",
+    name: "Wopee.io",
+    url: "https://wopee.io",
+  },
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "EUR",
+    description:
+      "Free and open source. Requires a Wopee.io account; free tier available.",
+    url: "https://wopee.io/pricing/",
+  },
+};
+
+const JSONLD_MCP_SOURCE = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareSourceCode",
+  name: "wopee-mcp",
+  description:
+    "Wopee.io's Model Context Protocol server for agentic testing. Compatible with Claude Code, Claude Desktop, Cursor, VS Code, Windsurf, and any MCP client.",
+  codeRepository: "https://github.com/Wopee-io/wopee-mcp",
+  programmingLanguage: "TypeScript",
+  runtimePlatform: "Node.js",
+  url: "https://wopee.io/mcp/",
+  author: {
+    "@type": "Organization",
+    name: "Wopee.io",
+    url: "https://wopee.io",
+  },
+};
+
 const McpPage = () => {
   return (
     <Layout
       title="MCP Server for Autonomous Testing | Wopee.io"
       description="MCP server that connects Claude, Cursor, and other AI coding agents to Wopee.io. Dispatch autonomous testing agents, generate test artifacts, fetch execution results, and manage test suites — all from natural conversation."
     >
+      <Head>
+        <script type="application/ld+json">
+          {JSON.stringify(JSONLD_MCP_APP)}
+        </script>
+        <script type="application/ld+json">
+          {JSON.stringify(JSONLD_MCP_SOURCE)}
+        </script>
+      </Head>
       <HeroSection />
       <ProblemSection />
       <CapabilitiesSection />

--- a/src/pages/pricing/index.tsx
+++ b/src/pages/pricing/index.tsx
@@ -1,7 +1,82 @@
 import React from "react";
 
+import Head from "@docusaurus/Head";
 import Layout from "@theme/Layout";
 import Pricing from "@site/src/components/pricing/Pricing";
+
+const JSONLD_PRODUCT = {
+  "@context": "https://schema.org",
+  "@type": "Product",
+  name: "Wopee.io",
+  description:
+    "Autonomous AI testing agents for web applications. Generate, run, and self-heal Playwright tests without writing scripts.",
+  brand: {
+    "@type": "Brand",
+    name: "Wopee.io",
+  },
+  url: "https://wopee.io/pricing/",
+  offers: [
+    {
+      "@type": "Offer",
+      name: "Starter",
+      description:
+        "For solo devs and side projects. Up to 10 active projects, autonomous test generation, Playwright + CI/CD ready, email and community support.",
+      price: "19",
+      priceCurrency: "EUR",
+      url: "https://wopee.io/pricing/",
+      availability: "https://schema.org/InStock",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: "19",
+        priceCurrency: "EUR",
+        unitText: "user/month",
+        billingIncrement: 1,
+      },
+    },
+    {
+      "@type": "Offer",
+      name: "Basic",
+      description:
+        "For growing product teams. Up to 100 active projects, team user management, onboarding assistance, and everything in Starter.",
+      price: "79",
+      priceCurrency: "EUR",
+      url: "https://wopee.io/pricing/",
+      availability: "https://schema.org/InStock",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: "79",
+        priceCurrency: "EUR",
+        unitText: "user/month",
+        billingIncrement: 1,
+      },
+    },
+    {
+      "@type": "Offer",
+      name: "Premium",
+      description:
+        "For high-velocity engineering orgs. Unlimited projects, advanced user management and roles, priority support, and everything in Basic.",
+      price: "179",
+      priceCurrency: "EUR",
+      url: "https://wopee.io/pricing/",
+      availability: "https://schema.org/InStock",
+      priceSpecification: {
+        "@type": "UnitPriceSpecification",
+        price: "179",
+        priceCurrency: "EUR",
+        unitText: "user/month",
+        billingIncrement: 1,
+      },
+    },
+    {
+      "@type": "Offer",
+      name: "Enterprise",
+      description:
+        "Unlimited everything, on-premise deployment, SSO, RBAC and audit logs, dedicated CSM and SLA, custom integrations, security review and DPA. Talk to founders for pricing.",
+      url: "https://wopee.io/book-demo/",
+      availability: "https://schema.org/InStock",
+    },
+  ],
+};
 
 const PricingPage = () => {
   return (
@@ -9,6 +84,11 @@ const PricingPage = () => {
       title="Pricing | Wopee.io"
       description="Simple, transparent pricing for Wopee.io AI testing agents. Start free, upgrade as you grow. No credit card required to get started."
     >
+      <Head>
+        <script type="application/ld+json">
+          {JSON.stringify(JSONLD_PRODUCT)}
+        </script>
+      </Head>
       <main className="container">
         <Pricing />
       </main>

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,30 @@
+# Wopee.io
+
+> Wopee.io builds autonomous AI testing agents for web applications. It is for QA engineers, SDETs, and engineering teams who want to stop hand-writing and babysitting test scripts. The agents explore an app, generate Playwright test cases, run them across browsers, self-heal when the UI changes, and surface visual and functional regressions. Typical wins: 85% less test maintenance, fewer flaky tests, faster CI, and coverage on flows that were previously too costly to automate. Available as cloud SaaS, on-premise deployment, and a Model Context Protocol (MCP) server that plugs into Claude, ChatGPT, Cursor, and other AI coding agents.
+
+## Core pages
+- [Home](https://wopee.io/): What Wopee.io is, who uses it, headline benefits, and how it fits into a modern test stack.
+- [Pricing](https://wopee.io/pricing/): Starter (€19/user/mo), Basic (€79/user/mo), Premium (€179/user/mo), and Enterprise (on-prem, SSO, dedicated CSM). Free to start, no credit card required, 14-day money-back guarantee.
+- [AI Testing Agents](https://wopee.io/ai-testing-agents/): How the autonomous agents explore, generate, run, and maintain tests without manual scripting.
+- [MCP Server](https://wopee.io/mcp/): Wopee.io's Model Context Protocol server — connect Claude, Cursor, VS Code, Windsurf, or any MCP client and dispatch testing agents from natural-language conversation.
+- [About](https://wopee.io/about-us/): Team, mission, investors, and contact (help@wopee.io, wopee labs s.r.o., Prague).
+- [Book a demo](https://wopee.io/book-demo/): 30-minute call with the founders.
+
+## Documentation
+- [Docs home](https://docs.wopee.io/): Setup, concepts, integrations, and reference for the Wopee.io platform.
+- [MCP guide](https://docs.wopee.io/guides/wopee-mcp/): Step-by-step integration of the Wopee.io MCP server with Claude Code, Claude Desktop, Cursor, VS Code, and Windsurf.
+- [Tools and assertions](https://docs.wopee.io/concepts/tools-and-assertions/): The set of agent tools and assertion types used by autonomous tests.
+
+## Key blog posts
+- [Self-Healing Tests in 2026](https://wopee.io/blog/self-healing-in-sw-test-automation/): How auto-repairing locators cut test maintenance by up to 80%, with tool comparisons and CI integration tips.
+- [Predictive Test Selection Explained](https://wopee.io/blog/predictive-test-selection/): Using AI to run only the tests most likely to fail for a given change — cutting CI time by up to 50% without losing coverage.
+- [Playwright Bot: AI-Generated Playwright Tests, No Code](https://wopee.io/blog/playwright-bot-ai-powered-test-automation/): How AI generates, runs, and maintains Playwright tests automatically, and how it compares to Playwright codegen.
+- [Playwright Visual Testing: Complete Setup Guide (2026)](https://wopee.io/blog/getting-started-with-playwright-visual-testing/): Install Playwright, write your first screenshot test, manage baselines, and wire visual checks into CI.
+- [AI Testing Agents in 2026: Hype, Reality, and What Actually Works](https://wopee.io/blog/ai-testing-agents/): A grounded look at which AI testing capabilities are real today and where the field is heading.
+- [Top 5 Applitools Alternatives for Visual Testing](https://wopee.io/blog/applitools-alternatives/): Wopee.io, Percy, LambdaTest, Chromatic, and BackstopJS compared on pricing, setup complexity, and maintenance.
+
+## Optional
+- [Sitemap](https://wopee.io/sitemap.xml)
+- [Robots](https://wopee.io/robots.txt)
+- [GitHub: wopee-mcp](https://github.com/Wopee-io/wopee-mcp)
+- [npm: wopee-mcp](https://www.npmjs.com/package/wopee-mcp)


### PR DESCRIPTION
## Summary

Make wopee.io maximally machine-readable for LLM crawlers (ChatGPT, Claude, Perplexity, Gemini) and rich-snippet eligible in Google.

- **`static/llms.txt`** following the [llmstxt.org](https://llmstxt.org/) spec — site description, core pages, docs, top blog posts. Anthropic and OpenAI both crawl this.
- **JSON-LD structured data** on three high-value pages, injected via Docusaurus `<Head>`:
  - Home: `Organization` + `SoftwareApplication`
  - Pricing: `Product` with one `Offer` per plan (Starter/Basic/Premium/Enterprise) — pulled from the actual `PlanCards` array, no invented prices.
  - MCP: `SoftwareApplication` + `SoftwareSourceCode` (mentions Claude/Cursor/VS Code/Windsurf compatibility, GitHub repo, npm package).
- **Answer-first TL;DR opener + `FAQPage` JSON-LD** (6 PAA-style questions each) on four high-impression / low-CTR blog posts:
  - `playwright-bot-ai-powered-test-automation` (3 437 impr, 0.47% CTR, pos 10.4)
  - `getting-started-with-playwright-visual-testing` (3 709 impr, 0.24% CTR, pos 10.3)
  - `ai-testing-agents` (3 067 impr, 0.23% CTR, pos 18.2)
  - `applitools-alternatives` — already had an answer-first opener, only added FAQ JSON-LD.

## Why now

LLM referral traffic is small but growing (~24 LLM sessions over the last 8 weeks across chatgpt.com, perplexity, claude.ai, gemini). The MCP page at `docs.wopee.io/guides/wopee-mcp/` already pulls 22.58% CTR — the best on the site — confirming LLM/AI users click through when discoverable. The targeted blogs are the ones GSC says we are bleeding on: high impressions, awful CTR, mid-page-1-or-2 positions where a richer snippet flips the click ratio.

The pattern matches the existing `about-us` page, which already uses Organization JSON-LD via `<Head>`.

## Test plan

- [x] `yarn build` passes (broken-anchor warning is pre-existing on `applitools-alternatives`, unrelated to this PR)
- [x] `static/llms.txt` ships to `build/llms.txt` (Docusaurus serves `static/` at root, so `wopee.io/llms.txt` resolves once deployed)
- [x] All 9 JSON-LD blocks parse as valid JSON in the built HTML (verified with a Node script: 2 on home, 1 on pricing, 2 on MCP, 1 FAQ on each of 4 blogs — Docusaurus also adds its existing `BlogPosting` JSON-LD to each blog post)
- [ ] Spot-check `https://validator.schema.org/` against the deployed URLs after merge
- [ ] Confirm `wopee.io/llms.txt` is reachable after deploy
- [ ] Re-check GSC CTR on the four touched posts in 2-4 weeks