### PR TITLE
[website] Restore right-side TOC on blog post pages

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -359,6 +359,37 @@ a.navbar__item:hover {
   display: none;
 }
 
+/* ---------- Blog post sidebar TOC ---------- */
+.blog-post-page .table-of-contents {
+  font-size: 0.85rem;
+  border-left: none;
+  padding-left: 0;
+}
+
+.blog-post-page .table-of-contents__link {
+  display: block;
+  color: var(--ifm-color-emphasis-700);
+  border-left: 2px solid transparent;
+  padding: 0.25rem 0 0.25rem 0.75rem;
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease;
+}
+
+.blog-post-page .table-of-contents__link:hover {
+  color: var(--ifm-color-primary);
+  border-left-color: var(--ifm-color-emphasis-300);
+}
+
+.blog-post-page .table-of-contents__link--active {
+  color: var(--ifm-color-primary);
+  border-left-color: var(--ifm-color-primary);
+  background-color: rgba(255, 204, 0, 0.06);
+  font-weight: 600;
+}
+
+[data-theme="light"] .blog-post-page .table-of-contents__link--active {
+  background-color: rgba(112, 48, 160, 0.06);
+}
+
 /* ---------- Blog list page ---------- */
 .blog-list-page .pagination-nav {
   border-top: 1px solid var(--ifm-color-emphasis-200);

--- a/src/theme/BlogPostPage/index.tsx
+++ b/src/theme/BlogPostPage/index.tsx
@@ -11,6 +11,7 @@ import BlogPostPaginator from "@theme/BlogPostPaginator";
 import BlogPostPageMetadata from "@theme/BlogPostPage/Metadata";
 import BlogPostPageStructuredData from "@theme/BlogPostPage/StructuredData";
 import ContentVisibility from "@theme/ContentVisibility";
+import TOC from "@theme/TOC";
 import type { Props } from "@theme/BlogPostPage";
 
 import ReadingProgressBar from "@/components/blog/ReadingProgressBar";
@@ -20,8 +21,14 @@ import InPostCTA from "@/components/blog/InPostCTA";
 import RelatedPosts from "@/components/blog/RelatedPosts";
 
 function BlogPostPageContent({ children }: { children: ReactNode }): ReactNode {
-  const { metadata } = useBlogPost();
-  const { nextItem, prevItem, permalink, title, tags } = metadata;
+  const { metadata, toc } = useBlogPost();
+  const { nextItem, prevItem, permalink, title, tags, frontMatter } = metadata;
+  const {
+    hide_table_of_contents: hideTableOfContents,
+    toc_min_heading_level: tocMinHeadingLevel,
+    toc_max_heading_level: tocMaxHeadingLevel,
+  } = frontMatter;
+  const showToc = !hideTableOfContents && toc.length > 0;
   const {
     siteConfig: { url: siteUrl },
   } = useDocusaurusContext();
@@ -31,28 +38,52 @@ function BlogPostPageContent({ children }: { children: ReactNode }): ReactNode {
     <BlogLayout>
       <ContentVisibility metadata={metadata} />
 
-      <article className="mx-auto max-w-3xl">
-        <BlogPostHero />
-
-        <div className="markdown">{children}</div>
-
-        <div className="mt-10 pt-6 border-t border-gray-200 dark:border-gray-800">
-          <ShareButtons url={fullUrl} title={title} />
-        </div>
-
-        <InPostCTA />
-
-        <RelatedPosts
-          currentPermalink={permalink}
-          tags={tags.map((t) => t.label)}
-        />
-
-        {(nextItem || prevItem) && (
-          <div className="mt-12">
-            <BlogPostPaginator nextItem={nextItem} prevItem={prevItem} />
-          </div>
+      <div
+        className={clsx(
+          "mx-auto",
+          showToc
+            ? "max-w-6xl lg:grid lg:grid-cols-[minmax(0,1fr)_240px] lg:gap-12"
+            : "max-w-3xl",
         )}
-      </article>
+      >
+        <article className={showToc ? "min-w-0" : undefined}>
+          <BlogPostHero />
+
+          <div className="markdown">{children}</div>
+
+          <div className="mt-10 pt-6 border-t border-gray-200 dark:border-gray-800">
+            <ShareButtons url={fullUrl} title={title} />
+          </div>
+
+          <InPostCTA />
+
+          <RelatedPosts
+            currentPermalink={permalink}
+            tags={tags.map((t) => t.label)}
+          />
+
+          {(nextItem || prevItem) && (
+            <div className="mt-12">
+              <BlogPostPaginator nextItem={nextItem} prevItem={prevItem} />
+            </div>
+          )}
+        </article>
+
+        {showToc && (
+          <aside className="hidden lg:block">
+            <div className="sticky top-[calc(var(--ifm-navbar-height,80px)+1rem)] max-h-[calc(100vh-var(--ifm-navbar-height,80px)-2rem)] overflow-y-auto pb-8">
+              <p className="text-xs font-bold uppercase tracking-widest text-gray-500 dark:text-gray-400 mb-3">
+                On this page
+              </p>
+              <TOC
+                toc={toc}
+                minHeadingLevel={tocMinHeadingLevel}
+                maxHeadingLevel={tocMaxHeadingLevel}
+              />
+            </div>
+          </aside>
+        )}
+      </div>
     </BlogLayout>
   );
 }


### PR DESCRIPTION
## Summary

Brings back the per-post table-of-contents sidebar that the original Docusaurus layout had. We dropped it during the blog redesign in #181 in favour of a centered narrow column; this PR puts it back as a sticky right rail on wide viewports.

## Behaviour

- **`lg+` (≥ 1024px)**: 2-column grid — article (~720px) + TOC (240px).
- **Below `lg`**: TOC is hidden, article keeps the wider grid container but stays comfortable.
- **No TOC**: posts where `toc.length === 0` (no `##`/`###` headings) or `hide_table_of_contents: true` is set fall back to the original centered `max-w-3xl` column — no empty rail.
- **Honours frontmatter**: `hide_table_of_contents`, `toc_min_heading_level`, `toc_max_heading_level`.

## Styling

Active link uses brand yellow in dark mode (`#ffcc00`) and brand purple in light mode (`#7030a0`), with a left border and a subtly tinted background. Hover state mirrors with a softer border.

Sidebar sticks under the navbar via `top: calc(var(--ifm-navbar-height) + 1rem)` and scrolls internally if the TOC is taller than the viewport.

## Files

- `src/theme/BlogPostPage/index.tsx` — wrap article in conditional 2-col grid; render `<TOC>` in `<aside>`.
- `src/css/custom.css` — TOC link styling for the blog-post-page scope.

## Test plan

- [ ] `npm start`, open any post with multiple `##` headings (e.g. `/blog/ai-testing-agents/`) → TOC visible on the right at desktop widths, sticky as you scroll.
- [ ] Click a TOC entry → page scrolls to the heading; the active entry is highlighted in brand colour.
- [ ] Resize to ≤ 1023px → TOC disappears, article stays centered.
- [ ] Open a post with no headings (or with `hide_table_of_contents: true`) → no empty TOC column.
- [ ] Toggle light/dark mode → active-link colour swaps between purple and yellow.
- [ ] `npm run build` succeeds.