### PR TITLE
[website] Gate gtag + GTM to production builds only

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,10 +187,19 @@ const config = {
             "/testing-bot/**",
           ],
         },
-        gtag: { trackingID: "G-PVTHWLV51B" },
-        googleTagManager: {
-          containerId: "GTM-T54MTRSZ",
-        },
+        // Only emit analytics in production builds. The gtag plugin's
+        // onRouteDidUpdate calls window.gtag() unguarded; in dev (and any
+        // browser with an ad/privacy blocker) window.gtag is undefined, so
+        // every internal navigation — including in-page anchor clicks like
+        // the blog post TOC — throws an "Uncaught runtime error" overlay.
+        gtag:
+          process.env.NODE_ENV === "production"
+            ? { trackingID: "G-PVTHWLV51B" }
+            : undefined,
+        googleTagManager:
+          process.env.NODE_ENV === "production"
+            ? { containerId: "GTM-T54MTRSZ" }
+            : undefined,
       },
     ],
   ],


### PR DESCRIPTION
## Summary

`@docusaurus/plugin-google-gtag`'s client module calls `window.gtag(...)` without a `typeof` guard on every route change ([gtag.js:17](https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-plugin-google-gtag/src/gtag.ts#L17)) — including in-page hash navigation (blog post TOC clicks, anchor links inside MDX, etc.).

In dev, and in any browser with an ad/privacy blocker, `window.gtag` is undefined → the call throws → webpack-dev-server's overlay surfaces it as a fatal `Uncaught runtime error`.

## Fix

Gate both `gtag` and `googleTagManager` to `NODE_ENV === "production"`.

- **Dev**: no analytics scripts loaded, no overlay errors, dev sessions stop polluting GA with fake page views.
- **Production**: unchanged — both scripts ship and fire as before. Verified by inspecting `build/blog/index.html` (5 `googletagmanager.com` references after `npm run build`).

## Test plan

- [ ] `npm start` → click any anchor link in a blog post → no overlay error.
- [ ] `npm run build` → `grep googletagmanager.com build/blog/index.html` returns matches → analytics scripts present in prod build.
- [ ] After deploy, GA real-time view shows traffic as before.

## Notes

This is a Docusaurus plugin design choice that surfaces in dev only. Reported upstream historically; gating per-environment is the standard workaround.