### PR TITLE
[website] Sharpen /blog landing copy for SEO and GEO

### DIFF
--- a/src/theme/BlogListPage/index.tsx
+++ b/src/theme/BlogListPage/index.tsx
@@ -43,14 +43,14 @@ function BlogListPageContent(props: Props): ReactNode {
     <BlogLayout>
       <header className="mb-10 lg:mb-14">
         <p className="text-sm font-bold uppercase tracking-widest text-secondary-wopee dark:text-primary-wopee mb-3">
-          Wopee Blog
+          Wopee.io · Engineering Blog
         </p>
         <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight m-0 text-gray-900 dark:text-white">
-          Notes on testing, AI agents &amp; quality
+          AI testing agents for web apps
         </h1>
         <p className="mt-4 text-lg text-gray-600 dark:text-gray-400">
-          Practical playbooks from building and shipping autonomous testing
-          tooling at Wopee.io.
+          How AI testing agents work in production — from the engineers
+          building them at Wopee.io.
         </p>
       </header>
 


### PR DESCRIPTION
## Summary

The /blog landing currently reads:

> **Wopee Blog**
> *Notes on testing, AI agents & quality*
> Practical playbooks from building and shipping autonomous testing tooling at Wopee.io.

Calm, modest — and tells search engines nothing about what we own. This PR sharpens it.

## New copy

> **Wopee.io · Engineering Blog**
> *AI testing agents for web apps*
> How AI testing agents work in production — from the engineers building them at Wopee.io.

## Why each change

**Eyebrow** — "Wopee.io · Engineering Blog"
Adds a topical signal: this is an *engineering* publication, not a marketing blog. Helps both human readers and topic-extraction in LLMs.

**H1** — "AI testing agents for web apps"
Replaces the generic three-noun list ("testing, AI agents & quality") with the single high-intent commercial keyword we actually rank for and convert on.

**Sub** — "How AI testing agents work in production — from the engineers building them at Wopee.io."
- "How X work in production" is a declarative citation pattern that LLM answer engines (Perplexity, ChatGPT, Claude, Gemini) preferentially cite over hedged phrasing.
- "in production" carries authority — separates from theory blogs.
- "from the engineers building them" is the author-credibility signal.

## Files

- `src/theme/BlogListPage/index.tsx` — 4 lines changed.

## Test plan

- [ ] Open `/blog/` → header reads as above; lays out the same as before.
- [ ] No regressions on mobile / dark mode (no styling changed, only text).