### PR TITLE
[website] Pass URL-derived projectName to signup-embedded

### DIFF
--- a/src/components/home-page/vibe/LoginDialog.tsx
+++ b/src/components/home-page/vibe/LoginDialog.tsx
@@ -28,6 +28,15 @@ const LOGIN_BUTTONS = [
   },
 ];
 
+const buildProjectName = (appUrl: string): string => {
+  try {
+    const normalized = /^https?:\/\//i.test(appUrl) ? appUrl : `https://${appUrl}`;
+    return new URL(normalized).hostname.replace(/^www\./i, "");
+  } catch {
+    return appUrl;
+  }
+};
+
 const LoginDialog = ({
   mode,
   prompt,
@@ -55,6 +64,7 @@ const LoginDialog = ({
         prompt: encodeURIComponent(prompt),
         appUrl: encodeURIComponent(appUrl),
         appType: encodeURIComponent(appType),
+        projectName: encodeURIComponent(buildProjectName(appUrl)),
         provider: encodeURIComponent(provider),
       });
     }


### PR DESCRIPTION
## Summary

When a user submits the website hero form with the **Your App** option, the resulting cmd project is currently named `Your Application project` (generic, indistinguishable across users).

This PR adds a `projectName` query parameter to the `signup-embedded` URL, derived from the app URL hostname (e.g. `example.com`). Once cmd starts honoring this param the project will be named after the URL the user actually typed in.

## Changes

- [src/components/home-page/vibe/LoginDialog.tsx](src/components/home-page/vibe/LoginDialog.tsx): add `buildProjectName(appUrl)` and pass `projectName` alongside the existing `appUrl` / `appType` / `prompt` params.

## Test plan

- [ ] Open the homepage hero form, enter a custom URL (e.g. `https://www.foo.com/bar`), pick Your App, click **Test now!**
- [ ] In the opened `signup-embedded` URL, verify a `projectName=foo.com` query param is present
- [ ] Verify the demo presets (Website / E-commerce / Banking) also include a sensible `projectName` derived from their preset URL

Closes autonomous-testing/backlog#3907