### PR TITLE
fix(blog): use 16:9 aspect ratio for featured-post hero image

### DIFF
--- a/src/components/blog/FeaturedPostHero.tsx
+++ b/src/components/blog/FeaturedPostHero.tsx
@@ -32,7 +32,7 @@ export default function FeaturedPostHero({ post, className }: FeaturedPostHeroPr
         <Link
           to={permalink}
           aria-label={title}
-          className="block aspect-[16/10] lg:aspect-auto lg:min-h-[420px] overflow-hidden bg-gradient-to-br from-secondary-wopee/30 to-primary-wopee/30 no-underline group"
+          className="block aspect-[16/9] overflow-hidden bg-gradient-to-br from-secondary-wopee/30 to-primary-wopee/30 no-underline group"
         >
           {cover ? (
             <img


### PR DESCRIPTION
## Summary

The "Latest post" featured card on the blog landing page renders 16:9 source images **cropped**. You can see chart-text fragments leaking from the image's left edge on the current PR #189 preview — the image is scaled up and clipped, not contained.

**Root cause** ([FeaturedPostHero.tsx:35](src/components/blog/FeaturedPostHero.tsx#L35)): the image container uses `lg:aspect-auto lg:min-h-[420px]`. At lg+ breakpoints the image column stretches to match the text column's height, and `object-cover` then crops the 16:9 image horizontally to fill the taller container.

**Fix**: use `aspect-[16/9]` at all breakpoints — same pattern `BlogPostCard.tsx` uses for the tile grid below the featured card, which renders correctly. Source images are 1672×941 (16:9.04), so the container now matches the natural ratio.

## Diff

```diff
-  className="block aspect-[16/10] lg:aspect-auto lg:min-h-[420px] overflow-hidden ..."
+  className="block aspect-[16/9] overflow-hidden ..."
```

## Test plan

- [ ] Deploy preview shows the latest-post hero image uncropped (chart fully visible)
- [ ] No visual regression on the tile grid below (those already use 16:9)
- [ ] Mobile narrows still look fine (single column stack, image at full width with 16:9 ratio)