### PR TITLE
fix(seo): add og:site_name to clear Ahrefs OG-incomplete warnings

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -213,9 +213,15 @@ const config = {
     {
       // Replace with your project's social card
       image: "img/wopee-social-card.jpg",
-      // OG protocol requires og:type. Docusaurus's classic theme doesn't emit a default;
-      // the blog plugin overrides this with og:type=article on blog pages.
-      metadata: [{ property: "og:type", content: "website" }],
+      // Docusaurus's classic theme emits og:title, og:description, og:image, og:url,
+      // og:locale and twitter:card/twitter:image automatically. It does NOT emit
+      // og:type or og:site_name — both flagged by Ahrefs as "Open Graph tags
+      // incomplete" across the whole site. The blog plugin overrides og:type with
+      // "article" on individual blog posts.
+      metadata: [
+        { property: "og:type", content: "website" },
+        { property: "og:site_name", content: "Wopee.io" },
+      ],
       // https://docusaurus.io/docs/api/themes/configuration#color-mode---dark-mode
       colorMode: {
         defaultMode: "dark",


### PR DESCRIPTION
## Background

Ahrefs' May 22 wopee.io crawl flagged **73 URLs** as having incomplete Open Graph tags — virtually every page on the site. Because OG tags live in the Docusaurus theme/head config and propagate to every page, a single template-level fix clears all 73 at once.

## What was missing per page type

Audit of the existing build output (`build/*/index.html`) showed these OG/Twitter tags emitted automatically by Docusaurus across **homepage, blog index, blog posts, pricing, about-us**:

- `og:title`, `og:description`, `og:image`, `og:url`, `og:locale` — present
- `og:type` — present (set to `website` site-wide, overridden to `article` on blog posts via `src/theme/BlogPostPage/Metadata/index.tsx`)
- `twitter:card`, `twitter:image` — present
- **`og:site_name` — MISSING site-wide**

That's the only tag from Ahrefs' OG checklist that was missing.

## What this PR adds

Adds `og:site_name: Wopee.io` to `themeConfig.metadata` in `docusaurus.config.js`. Verified via `npx docusaurus build --no-minify`:

- homepage now emits `og:site_name`
- blog post still emits `og:type=article` (blog plugin override wins) AND `og:site_name` (site-wide metadata wins where blog plugin doesn't override)

## What Ahrefs may still flag (follow-ups, not in this PR)

- **`twitter:title` / `twitter:description`** — not currently emitted. Twitter clients fall back to `og:title` / `og:description` when these are absent, so cards render correctly. Ahrefs has a separate "Twitter card meta tags incomplete" issue if this becomes a problem; can be added later via a small `src/theme/Layout` override that mirrors og:* into twitter:*.
- **`twitter:site` (`@wopee_io` handle)** — no Twitter/X handle is referenced anywhere in the repo (only LinkedIn, YouTube, GitHub). Not adding to avoid pointing at a handle that may not exist.

## Test plan

- [ ] After merge + deploy, view-source on https://wopee.io/ and confirm `<meta property="og:site_name" content="Wopee.io">` is present in `<head>`
- [ ] Same check on https://wopee.io/blog/, https://wopee.io/pricing/, https://wopee.io/about-us/, and one blog post (e.g. /blog/ai-testing-agents/)
- [ ] Next Ahrefs crawl shows the "Open Graph tags incomplete" issue count drop from 73 to 0 (or close to it)