### PR TITLE
fix(seo): trim 7 blog titles to under 60 chars

### DIFF
--- a/blog/2024-05-20-grow-your-business-with-automation/index.md
+++ b/blog/2024-05-20-grow-your-business-with-automation/index.md
@@ -1,6 +1,6 @@
 ---
 slug: grow-your-business-with-automation
-title: Grow Your Business without Scaling Your Resources with Automation
+title: Grow Your Business via Automation, Not Headcount
 description: "Learn how to grow your business without scaling your QA team. See how test automation helps you ship faster, reduce costs, and maintain quality at scale."
 authors: marcel
 tags: [basics, automation, business, efficiency]

--- a/blog/2024-07-23-self-healing-in-sw-test-automation/index.md
+++ b/blog/2024-07-23-self-healing-in-sw-test-automation/index.md
@@ -1,6 +1,6 @@
 ---
 slug: self-healing-in-sw-test-automation
-title: "Self-Healing Tests in 2026: How Auto-Repair Cuts Maintenance by 80%"
+title: "Self-Healing Tests: Cut Maintenance by 80%"
 description: "Self-healing test automation auto-repairs broken selectors when your UI changes, cutting maintenance up to 80%. How it works + top tools compared."
 authors: marcel
 tags: [automation, self-healing, ai, machine-learning, ci-cd, reliability]

--- a/blog/2024-09-02-7-principles-for-sucessful-web-app-test-automation/index.md
+++ b/blog/2024-09-02-7-principles-for-sucessful-web-app-test-automation/index.md
@@ -1,6 +1,6 @@
 ---
 slug: 7-principles-for-successful-web-app-test-automation
-title: "Web App Test Automation: 7 Key Principles for Long-Term Success"
+title: "Web App Test Automation: 7 Key Principles"
 description: "Seven proven principles for web app test automation that scales — from test design to CI integration. Practical guide for QA engineers."
 authors: marcel
 tags: [test-automation, web-app-testing, quality-assurance, essentials]

--- a/blog/2024-09-16-getting-started-w-wopee-io/index.md
+++ b/blog/2024-09-16-getting-started-w-wopee-io/index.md
@@ -1,6 +1,6 @@
 ---
 slug: getting-started-w-wopee-io-automation
-title: "Getting Started with Wopee.io: Automate Web App Testing; No Coding Required"
+title: "Getting Started with Wopee.io: No-Code Testing"
 description: "Get started with Wopee.io in minutes — no coding required. Learn how to automate web app testing with AI, from account setup to your first autonomous test run."
 authors: marcel
 tags: [playwright, automation, testing, AI]

--- a/blog/2024-12-19-ai-testing-agents/index.md
+++ b/blog/2024-12-19-ai-testing-agents/index.md
@@ -1,6 +1,6 @@
 ---
 slug: ai-testing-agents
-title: "AI Testing Agents in 2026: Hype, Reality, and What Actually Works"
+title: "AI Testing Agents: Hype, Reality, and What Works"
 description: "AI testing agents promise to automate QA end-to-end — but which capabilities are real and which are hype? What works in 2026 and where to start."
 authors: marcel
 tags: [testing, automation, AI]

--- a/blog/2025-05-26-vibe-engineering/index.md
+++ b/blog/2025-05-26-vibe-engineering/index.md
@@ -1,6 +1,6 @@
 ---
 slug: vibe-testing-coding-engineering
-title: "New software era: Vibe Coding, Vibe Testing, and Vibe Engineering"
+title: "Vibe Coding, Vibe Testing, and Vibe Engineering"
 description: "Embracing the “Vibe” in Software: Vibe Coding, Vibe Testing, and Vibe Engineering."
 authors: marcel
 tags:

--- a/blog/2026-05-02-flaky-tests-complete-guide/index.md
+++ b/blog/2026-05-02-flaky-tests-complete-guide/index.md
@@ -1,6 +1,6 @@
 ---
 slug: flaky-tests-complete-guide
-title: "Flaky Tests in E2E Test Suites: The Complete Guide to Detection, Root Causes, and Remediation"
+title: "Flaky Tests in E2E Suites: Detection & Fixes"
 description: "Flaky tests affect 16% of tests at Google and erode CI trust. Learn root causes, detection methods, and proven remediation patterns for E2E test suites."
 tags: [flaky-tests, e2e-testing, test-automation, ci-cd, playwright, test-reliability, software-quality]
 image: ./ci-trust-erosion.webp


### PR DESCRIPTION
## Summary

Ahrefs' May 22 wopee.io crawl flagged 88 URLs with `<title>` over 60 chars (Google's typical SERP display cutoff). This PR trims the **blog post** offenders — 7 frontmatter titles whose rendered `<title>` (with the " | Wopee.io" suffix Docusaurus appends) exceeded 60 chars.

Docs/landing pages can be a follow-up PR.

## How offenders were identified

```bash
for f in blog/*/index.md; do
  title=$(awk '/^title:/ {sub(/^title: *"?/, ""); sub(/"?$/, ""); print; exit}' "$f")
  len=${#title}
  if [ "$len" -gt 60 ]; then
    echo "LEN=$len  $f"
    echo "  $title"
  fi
done
```

Result: 7 blog posts had frontmatter titles 63-93 chars (which became 74-104 chars after Docusaurus appended " | Wopee.io").

## Result

- **7 of 7** blog-post offenders trimmed in this PR
- **0** deliberately left untouched — all 7 trimmed without losing core meaning
- Rendered `<title>` lengths now range **52-59 chars** (target was 50-58 for the frontmatter portion, ≤60 for full rendered title)
- Frontmatter-only edits; no body, slug, description, or other field touched
- Verified locally with `npx docusaurus build --no-minify` — built successfully

## Before / After

| Len before → after | Before | After |
| --- | --- | --- |
| 75 → 46 | Getting Started with Wopee.io: Automate Web App Testing; No Coding Required | Getting Started with Wopee.io: No-Code Testing |
| 93 → 44 | Flaky Tests in E2E Test Suites: The Complete Guide to Detection, Root Causes, and Remediation | Flaky Tests in E2E Suites: Detection & Fixes |
| 67 → 42 | Self-Healing Tests in 2026: How Auto-Repair Cuts Maintenance by 80% | Self-Healing Tests: Cut Maintenance by 80% |
| 63 → 41 | Web App Test Automation: 7 Key Principles for Long-Term Success | Web App Test Automation: 7 Key Principles |
| 65 → 48 | AI Testing Agents in 2026: Hype, Reality, and What Actually Works | AI Testing Agents: Hype, Reality, and What Works |
| 65 → 47 | New software era: Vibe Coding, Vibe Testing, and Vibe Engineering | Vibe Coding, Vibe Testing, and Vibe Engineering |
| 65 → 48 | Grow Your Business without Scaling Your Resources with Automation | Grow Your Business via Automation, Not Headcount |

Lengths are frontmatter `title:` only; add 11 chars for the " | Wopee.io" suffix to get the rendered `<title>` length.

## Trim philosophy

- Preserved the core keyword at the start (e.g. "Flaky Tests", "AI Testing Agents", "Self-Healing Tests").
- Dropped trailing fluff first: "The Complete Guide to Detection, Root Causes, and Remediation" → "Detection & Fixes"; "for Long-Term Success" → removed (already implied).
- Dropped year qualifiers ("in 2026") that age the title and add no SEO value.
- Dropped redundant subtitle prefixes (e.g. "New software era:") where the title still stands on its own.

## Pattern observation

The biggest offender pattern was **colon-subtitle bloat** — long descriptive subtitles after the main keyword. Trimming the subtitle was almost always the right move; the core keyword phrase before the colon is what carries the SEO weight.

## Diff stat

7 files changed, 7 insertions(+), 7 deletions(-) — one frontmatter `title:` line edited per file. Nothing else touched.

## Test plan

- [x] `npx docusaurus build --no-minify` succeeds
- [x] Spot-check rendered `<title>` for all 7 trimmed posts via `grep '<title>' build/blog/<slug>/index.html` — all 52-59 chars, all under 60
- [ ] Ahrefs re-crawl May 29: confirm the "Title too long" count drops by ~7