### PR TITLE
fix(seo): add 2 missing + trim 1 overlong + expand 1 short meta description

### DIFF
--- a/blog/2025-05-26-vibe-engineering/index.md
+++ b/blog/2025-05-26-vibe-engineering/index.md
@@ -1,7 +1,7 @@
 ---
 slug: vibe-testing-coding-engineering
 title: "Vibe Coding, Vibe Testing, and Vibe Engineering"
-description: "Embracing the “Vibe” in Software: Vibe Coding, Vibe Testing, and Vibe Engineering."
+description: "Vibe Coding, Vibe Testing, and Vibe Engineering: how AI-assisted tooling shifts developers into flow state and reshapes how modern software gets built."
 authors: marcel
 tags:
   [

--- a/src/pages/gdpr/index.md
+++ b/src/pages/gdpr/index.md
@@ -1,5 +1,6 @@
 ---
 title: Data Processing Agreement
+description: Data Processing Agreement between wopee labs s.r.o. and Wopee.io clients. GDPR-compliant terms covering personal data handling, subprocessors, and security.
 custom_edit_url: null
 ---
 

--- a/src/pages/mcp/index.tsx
+++ b/src/pages/mcp/index.tsx
@@ -605,7 +605,7 @@ const McpPage = () => {
   return (
     <Layout
       title="MCP Server for Autonomous Testing | Wopee.io"
-      description="MCP server that connects Claude, Cursor, and other AI coding agents to Wopee.io. Dispatch tests, generate artifacts, fetch results — all from natural conversation."
+      description="MCP server that connects Claude, Cursor, and other AI coding agents to Wopee.io. Dispatch tests, generate artifacts, and fetch results in chat."
     >
       <Head>
         <script type="application/ld+json">

--- a/src/pages/terms-and-conditions/index.md
+++ b/src/pages/terms-and-conditions/index.md
@@ -1,5 +1,6 @@
 ---
 title: General Terms and Conditions for provision of testing services concerning Wopee platform
+description: General Terms and Conditions governing use of the Wopee platform, subscriptions, and the contractual relationship between wopee labs s.r.o. and its clients.
 ---
 
 # General Terms and Conditions for provision of testing services concerning Wopee platform


### PR DESCRIPTION
## Summary

Ahrefs' May 22 wopee.io crawl flagged **65 URLs with missing/empty meta description** and **19 with description >160 chars**. Auditing the actual source files turned up **only 4 fixable offenders** — the rest are auto-generated Docusaurus pages (`/blog/tags/*`, `/blog/authors/`, client-redirect shims) that don't accept frontmatter.

This PR fixes the 4 source-level offenders.

## How offenders were identified

`scripts/seo-check-descriptions.mjs` walks `blog/*/index.{md,mdx}` + `src/pages/**` (both frontmatter and `<Layout description>` props):

```bash
node scripts/seo-check-descriptions.mjs --all
```

Output (before fixes):
```
Files scanned: 44
Missing/empty: 2
Too long (>160): 1
OK: 40
```

Plus one description flagged as too short by a separate `node -e` check (`< 110 chars`): `blog/2025-05-26-vibe-engineering` at 82 chars.

## Result

- **2 added**: `src/pages/gdpr/index.md`, `src/pages/terms-and-conditions/index.md`
- **1 trimmed**: `src/pages/mcp/index.tsx` (163 → 148 chars)
- **1 expanded**: `blog/2025-05-26-vibe-engineering/index.md` (82 → 151 chars)
- **0 left untouched** — every offender had enough content to write a meaningful description
- Frontmatter / `<Layout description>` only; no body, slug, or other field touched
- Audit script committed for reproducibility on future Ahrefs crawls

After fixes:
```
Files scanned: 44
Missing/empty: 0
Too long (>160): 0
OK: 43
```

## Before / After

| Page | Action | Before | After |
| --- | --- | --- | --- |
| `gdpr` | add | _(missing)_ | "Data Processing Agreement between wopee labs s.r.o. and Wopee.io clients. GDPR-compliant terms covering personal data handling, subprocessors, and security." (159) |
| `terms-and-conditions` | add | _(missing)_ | "General Terms and Conditions governing use of the Wopee platform, subscriptions, and the contractual relationship between wopee labs s.r.o. and its clients." (157) |
| `mcp` | trim 163→148 | "MCP server that connects Claude, Cursor, and other AI coding agents to Wopee.io. Dispatch tests, generate artifacts, fetch results — all from natural conversation." | "MCP server that connects Claude, Cursor, and other AI coding agents to Wopee.io. Dispatch tests, generate artifacts, and fetch results in chat." |
| `vibe-engineering` | expand 82→151 | "Embracing the "Vibe" in Software: Vibe Coding, Vibe Testing, and Vibe Engineering." | "Vibe Coding, Vibe Testing, and Vibe Engineering: how AI-assisted tooling shifts developers into flow state and reshapes how modern software gets built." |

## Why the 65 vs 4 gap

Built `build/` HTML inspection (`find build -name index.html | xargs grep -L 'name="description"'`) returned **101 pages with no description tag**. Breakdown:

| Source | Count | Fixable here? |
| --- | --- | --- |
| `/blog/tags/*` (auto-generated) | ~50 | No — these already carry `<meta name="robots" content="noindex">`, so search engines ignore them. Would need a theme swizzle. |
| `/blog/authors/` (auto-generated) | 1 | Same — would need a swizzle. |
| Client redirects (`/team`, `/lisbon`, `/contact-us`, `/ws*`, `/bot`, `/integrations`, …) | ~35 | No — these emit `<meta http-equiv="refresh">` and redirect immediately; no SEO surface. |
| `/billing/` (JS redirect to Stripe) | 1 | Excluded from sitemap; no SEO surface. |
| `/blog/top-5-applitools-alternatives-for-visual-testing--2024/` | 1 | Client-redirect shim to canonical slug. |
| Source-level (this PR) | **2 missing + 1 long + 1 short** | **Yes — fixed here.** |

Most of the auto-generated noindex tag pages and ephemeral redirect pages get crawled by Ahrefs but don't actually hurt SEO. A future PR could swizzle `BlogTagsListPage` / `BlogTagsPostsPage` to inject a description for cleanliness, but it's not load-bearing.

## Diff stat

```
 blog/2025-05-26-vibe-engineering/index.md |  2 +-
 scripts/seo-check-descriptions.mjs        | 113 +++++++++++++ (new audit util)
 src/pages/gdpr/index.md                   |  1 +
 src/pages/mcp/index.tsx                   |  2 +-
 src/pages/terms-and-conditions/index.md   |  1 +
 5 files changed, 115 insertions(+), 2 deletions(-)
```

4 content lines + 1 new audit script. The 4 content edits are one-line-each frontmatter / `<Layout description>` changes; nothing else touched.

## Trim / write philosophy

- Lead with the primary keyword/topic of the page.
- Name the value or insight in plain English; no clickbait.
- Stayed in 120–160 char window (Google SERP description cap).
- For the legal pages (GDPR, ToC), described the document's scope and the legal entity (wopee labs s.r.o.) since visitors arriving from search benefit from knowing it's the actual binding agreement.

## Test plan

- [x] `node scripts/seo-check-descriptions.mjs` reports 0 missing, 0 too-long
- [x] `npx docusaurus build --no-minify` succeeds
- [x] Spot-check rendered `<meta name="description">` in `build/{gdpr,terms-and-conditions,mcp,blog/vibe-testing-coding-engineering}/index.html` — all 4 land correctly in HTML
- [ ] Ahrefs re-crawl: confirm "Meta description too long" count drops by 1 and "missing" count drops by 2 (remaining will be auto-generated noindex tag pages and redirect shims — separate follow-up)

## Follow-up (not in this PR)

- Swizzle `BlogTagsListPage` and `BlogTagsPostsPage` to inject a templated `<meta name="description">` for tag/archive pages (cosmetic — they're already `noindex`).