### PR TITLE
fix(seo): add alt text to legacy imgs + extend short blog title

### DIFF
--- a/blog/2024-07-17-saving-50-percent-in-sw-testing/index.md
+++ b/blog/2024-07-17-saving-50-percent-in-sw-testing/index.md
@@ -1,6 +1,6 @@
 ---
 slug: saving-50-percent-in-sw-testing
-title: Cut SW Testing Costs by 50%
+title: Cut Software Testing Costs by 50% with AI
 description: "How teams cut software testing costs by 50% with AI-powered automation. Practical strategies and real data on reducing QA overhead."
 authors: marcel
 tags:

--- a/src/components/legacy/home-page/HomeCustomers.tsx
+++ b/src/components/legacy/home-page/HomeCustomers.tsx
@@ -45,6 +45,7 @@ export default function HomepageHowItWorks(): JSX.Element {
                 <img
                   className="avatar__photo avatar__photo--xl"
                   src="/img/customers/avatars/juraj-multitude.jpeg"
+                  alt="Juraj Žabka, Engineering Lead at Multitude"
                 />
                 <div className="avatar__intro text-left">
                   <div className="avatar__name">Juraj Žabka</div>
@@ -79,6 +80,7 @@ export default function HomepageHowItWorks(): JSX.Element {
               <img
                 className="avatar__photo avatar__photo--xl"
                 src="/img/customers/avatars/martin-livesport.webp"
+                alt="Martin Šimon, Test Automation Lead at Livesport"
               />
               <div className="avatar__intro text-left">
                 <div className="avatar__name">Martin Šimon</div>

--- a/src/components/legacy/home-page/HomeHowItWorks.tsx
+++ b/src/components/legacy/home-page/HomeHowItWorks.tsx
@@ -23,6 +23,7 @@ export default function HomepageHowItWorks(): JSX.Element {
             <img
               src={setupImg}
               className="object-contain"
+              alt="Simple bot setup interface for autonomous testing"
             />
           </div>
 
@@ -42,6 +43,7 @@ export default function HomepageHowItWorks(): JSX.Element {
             <img
               src={modelImg}
               className=" object-contain"
+              alt="Bot studies the app and generates regression tests"
             />
           </div>
 
@@ -61,6 +63,7 @@ export default function HomepageHowItWorks(): JSX.Element {
             <img
               src={cmdImg}
               className="object-contain"
+              alt="Wopee.io Commander dashboard for monitoring test results"
             />
           </div>
 


### PR DESCRIPTION
Clears two Ahrefs warnings from the May 22 crawl in one small content fix.

## Changes

### 1. `blog/2024-07-17-saving-50-percent-in-sw-testing/index.md` (Title too short — 1 URL)

Frontmatter title was 27 chars; Docusaurus appends ` | Wopee.io` so the rendered `<title>` was 38 chars — under Ahrefs' 40-char floor.

```diff
-title: Cut SW Testing Costs by 50%
+title: Cut Software Testing Costs by 50% with AI
```

Rendered: ``Cut Software Testing Costs by 50% with AI | Wopee.io`` (52 chars, mid SERP sweet spot 40–58). Also expanded the keyword `SW` → `Software Testing` for better SEO match against the post's description.

### 2. `src/components/legacy/home-page/HomeCustomers.tsx` (Missing alt text)

Two customer avatars on `/l/` had no `alt`:

```diff
                 <img
                   className="avatar__photo avatar__photo--xl"
                   src="/img/customers/avatars/juraj-multitude.jpeg"
+                  alt="Juraj Žabka, Engineering Lead at Multitude"
                 />
```

```diff
               <img
                 className="avatar__photo avatar__photo--xl"
                 src="/img/customers/avatars/martin-livesport.webp"
+                alt="Martin Šimon, Test Automation Lead at Livesport"
               />
```

### 3. `src/components/legacy/home-page/HomeHowItWorks.tsx` (Missing alt text)

Three step illustrations on `/l/` had no `alt`:

```diff
             <img
               src={setupImg}
               className="object-contain"
+              alt="Simple bot setup interface for autonomous testing"
             />
```

```diff
             <img
               src={modelImg}
               className=" object-contain"
+              alt="Bot studies the app and generates regression tests"
             />
```

```diff
             <img
               src={cmdImg}
               className="object-contain"
+              alt="Wopee.io Commander dashboard for monitoring test results"
             />
```

## Verification

- `npx docusaurus build --no-minify` → success (no new warnings introduced).
- Diff stat: 3 files, +6 −1.

## Notes

Ahrefs flagged 4 URLs missing alt text. All five raw `<img>` tags lacking `alt` live in two legacy components both rendered on `/l/`; the 4-URL count likely reflects per-image (rather than per-page) URL accounting in Ahrefs' report. Either way, every flagged image is now covered.