### PR TITLE
fix(seo): retarget last renamed-slug link to canonical to clear Ahrefs 3XX

### DIFF
--- a/blog/2024-10-17-ultimate-guide-to-visual-testing/index.md
+++ b/blog/2024-10-17-ultimate-guide-to-visual-testing/index.md
@@ -156,7 +156,7 @@ Open-source tools are cost-effective but may need more manual setup. Commercial 
 ### Criteria for Tool Selection
 
 Consider your team's size, budget, and technical requirements.
-For more ideas about potential tools, check out our other blog post: [Top 5 Applitools Alternatives for Visual Testing (2024)](https://wopee.io/blog/top-5-applitools-alternatives-for-visual-testing--2024/). You can also explore our GitHub repository for [getting started with Playwright Visual Testing](https://github.com/autonomous-testing/ws-getting-started-w-playwright-visual-testing).
+For more ideas about potential tools, check out our other blog post: [Top 5 Applitools Alternatives for Visual Testing (2024)](https://wopee.io/blog/applitools-alternatives/). You can also explore our GitHub repository for [getting started with Playwright Visual Testing](https://github.com/autonomous-testing/ws-getting-started-w-playwright-visual-testing).
 
 ## 6. Implementation Strategies for Test Automation Engineers
 


### PR DESCRIPTION
## Summary

Addresses the Ahrefs \"3XX redirect\" Warning class (21 URLs flagged in the May 22, 2026 crawl). Most flagged URLs are external/non-fixable; this PR cleans up the only remaining repo-side leak that PR #194 missed.

### Discovery commands

```bash
# 1. Build + dump sitemap URLs
npx docusaurus build --no-minify
grep -oE '<loc>[^<]+</loc>' build/sitemap.xml | sort

# 2. Confirm live sitemap is canonical-only
curl -s https://wopee.io/sitemap.xml | grep -oE '<loc>[^<]+</loc>' | sort

# 3. Search the repo for links to redirect-source URLs
for slug in 'blog/applitools' 'blog/autopilot-your-sw-testing' \
            'blog/getting-started-with-playwright-visual-testing' \
            'blog/livesport-visual-testing-w-wopee-io' \
            'blog/playwright-bot-ai-powered-test-automation' \
            'blog/test-design-techniques' \
            'blog/top-5-applitools-alternatives-for-visual-testing--2024' \
            'book-demo' 'marcel' 'gdpr' 'terms-and-conditions'; do
  grep -rE \"wopee\\.io/\${slug}\" --include='*.md' --include='*.mdx' \
       --include='*.js' --include='*.jsx' --include='*.ts' --include='*.tsx' .
done
```

### Findings

**Sitemap is already clean.** All 36 URLs in `build/sitemap.xml` (and the deployed `https://wopee.io/sitemap.xml`) use the canonical trailing-slash form. Docusaurus's `plugin-sitemap` auto-excludes:
- `noindex` pages (`/book-demo/`, `/gdpr/`, `/marcel/`, `/jan-beranek/`, `/ux/`, `/onboarding/`)
- `plugin-client-redirects` redirect sources (`/testing-bot`, `/team`, `/bot`, `/toc`, `/integrations`, `/blog/top-5-applitools-…--2024`, etc.)
- Anything matched by the existing `ignorePatterns` (tags, blog pagination, billing, `/l/**`, `/marcel/**`, etc.)

No `ignorePatterns` change was needed.

### What was actually flagged vs. what this PR fixes

| Ahrefs-flagged 3XX URL | Root cause | This PR? |
|---|---|---|
| `cmd.wopee.io/`, `cmd.wopee.io/api/auth/signin?…`, `cmd.wopee.io/projects` | NextAuth 302 to `/login` — intentional auth flow in the CMD app, not this repo | No (out of scope) |
| `http://wopee.io/`, `http://www.wopee.io/`, `https://www.wopee.io/` | HTTP->HTTPS and www->apex 301s from DNS/GitHub Pages | No (external/DNS) |
| `https://wopee.io/{gdpr,terms-and-conditions,book-demo,marcel}` (no slash) | GitHub Pages 301s `/path` -> `/path/` (because `trailingSlash: true`). Not in sitemap, no internal links (PR #194 fixed those). Source: external backlinks / Ahrefs index lag | No (external backlinks) |
| `https://wopee.io/blog/{applitools,applitools-alternatives,autopilot-your-sw-testing,getting-started-with-playwright-visual-testing,livesport-visual-testing-w-wopee-io,playwright-bot-ai-powered-test-automation,test-design-techniques}` (no slash) | Same trailing-slash 301. Not in sitemap, no internal links | No (external backlinks) |
| `https://wopee.io/blog/top-5-applitools-alternatives-for-visual-testing--2024/` | Renamed slug -> `plugin-client-redirects` 301 to `/blog/applitools-alternatives/`. Internal link still pointed at the old slug from `blog/2024-10-17-ultimate-guide-to-visual-testing/index.md`. PR #194's trailing-slash sweep missed this case because the URL already had a trailing slash | **Yes — only repo-side leak** |

### Fix (chosen Option C)

One-line edit in the blog post pointing at the renamed slug. No config change needed — `docusaurus.config.js` already has comprehensive `ignorePatterns` and the sitemap is canonical-only.

### Before/after sitemap

```
$ diff <(grep -oE 'https://[^<]+' build-before/sitemap.xml | sort) \
       <(grep -oE 'https://[^<]+' build-after/sitemap.xml | sort)
(no diff — sitemap was already clean; this PR only fixes one rendered HTML link)
```

```
$ grep -E '/(book-demo|marcel|gdpr|terms-and-conditions|blog/applitools|blog/autopilot|blog/livesport|blog/playwright-bot|blog/test-design-techniques|blog/top-5-applitools)[^/<]' build/sitemap.xml
(no matches — sitemap contains zero non-trailing-slash variants and zero redirect sources)
```

```
$ grep top-5-applitools build/blog/ultimate-guide-to-visual-testing/index.html
(before) <a href=\"https://wopee.io/blog/top-5-applitools-alternatives-for-visual-testing--2024/\">…</a>
(after)  <a href=\"https://wopee.io/blog/applitools-alternatives/\">…</a>
```

### Build verification

`npx docusaurus build --no-minify` succeeds (existing broken-anchor warnings are unrelated and pre-date this PR).

## Test plan

- [ ] Preview deploy loads
- [ ] `/blog/ultimate-guide-to-visual-testing/` -> the \"Top 5 Applitools Alternatives\" link goes directly to `/blog/applitools-alternatives/` (200 OK, no 301 hop)
- [ ] Next Ahrefs crawl (Fri May 29): the `…top-5-applitools…--2024/` URL drops from the 3XX class. The remaining flagged URLs are external/auth-flow and will need either source-site updates or just time as Ahrefs re-crawls.