### PR TITLE
content(blog): refresh Ultimate Guide to Visual Testing for 2026

### DIFF
--- a/blog/2024-10-17-ultimate-guide-to-visual-testing/index.md
+++ b/blog/2024-10-17-ultimate-guide-to-visual-testing/index.md
@@ -1,29 +1,36 @@
 ---
 slug: ultimate-guide-to-visual-testing
-title: Ultimate Guide to Visual Testing
-description: "Complete guide to visual testing for web apps. How visual regression testing works, when to use it, and which tools work best in modern CI/CD."
+title: "Ultimate Guide to Visual Testing (2026)"
+description: "2026 guide to visual testing: how visual regression testing works, when to use it, and which tools (Playwright, Percy, Applitools, Wopee.io) fit modern CI/CD."
 authors: marcel
 tags: [visual testing, test automation, visual regression testing]
 image: ./visual-bugs.webp
 ---
 
+Visual testing (or visual regression testing) captures screenshots of your web app, compares them against approved baselines, and flags pixel-level or structural differences as regressions. You need it whenever CSS, fonts, layout, or third-party widgets can break the UI without breaking functional tests. The 2026 toolchain spans Playwright's built-in `toHaveScreenshot()`, Percy and Chromatic for component review, Applitools and [Wopee.io](/visual-testing/) for AI-assisted diffing, and engines like pixelmatch and ODiff underneath.
+
+<!--truncate-->
+
 > ## Quality isn't just about code working.
 >
 > ## It's about users loving what they see.
 
-Most teams miss this simple truth: a **visually broken app is just as harmful as a technically broken one**.
+Most teams miss this simple truth: a **visually broken app is just as harmful as a technically broken one**. Visual testing is how you close that gap — and in 2026, with AI-assisted diffing, self-healing baselines, and component-level regression tooling now mainstream, the bar for what counts as good visual coverage has moved.
 
-Visual testing is how you close that gap.
+## TL;DR — Key Takeaways
 
-<!--truncate-->
-
-**This guide dives into making your web app look as good as it works.** It's a no-nonsense resource for test automation engineers and team leaders who want to enhance quality through visual testing.
+- **What it is:** Automated screenshot comparison against an approved baseline, with diffs flagged for review.
+- **When you need it:** Frequent CSS changes, design-system rollouts, multi-brand theming, responsive redesigns, third-party widgets, A/B tests.
+- **Tooling in 2026:** Playwright's `toHaveScreenshot()` for in-repo basics; [Percy](https://percy.io/), [Chromatic](https://www.chromatic.com/), [Applitools](https://applitools.com/), and [Wopee.io](/visual-testing/) for review UX, AI diffing, and baseline management.
+- **Diff engines that matter:** pixelmatch (Playwright default), SSIM, perceptual hashing (pHash), and ODiff — covered in depth in our [screenshot comparison algorithms guide](/blog/screenshot-comparison-algorithms-visual-testing/).
+- **The 2026 shift:** AI-assisted comparators reduce false positives on anti-aliasing and minor rendering noise; self-healing baselines auto-accept intentional UI changes without manual mass-approvals.
+- **Biggest pitfall:** Pixel-perfect comparators without environment control (Docker, font pinning) generate so many false positives that teams abandon visual testing entirely.
 
 ## Introduction
 
 Traditional testing doesn't cut it anymore. In the race to keep up with fast-paced web development, visual bugs are the silent killers of user experience. Functional tests keep things running, but visual testing is what keeps users happy.
 
-This guide is here to help test automation engineers and team leaders navigate the world of visual testing—whether you're just getting started or tackling the tough challenges of scaling it. Visual testing isn't just an add-on; it's the difference between a working app and a delightful user experience.
+This guide is for test automation engineers and team leaders navigating the world of visual testing — whether you're just getting started or scaling it across multi-environment CI/CD pipelines. The 2026 landscape rewards teams who pair a fast deterministic diff engine with AI-assisted triage and centralized baseline management. Visual testing isn't an add-on; it's the difference between a working app and a delightful user experience.
 
 ## 1. Understanding Visual Testing
 
@@ -37,15 +44,16 @@ Visual testing involves capturing screenshots of web pages and comparing them to
 
 ### Pixel-Perfect vs. Dynamic (AI) Visual Testing
 
-Visual testing strategies can be categorized as pixel-perfect or AI-driven. Pixel-perfect approaches compare screenshots pixel by pixel, which can lead to false positives due to minor differences like anti-aliasing. AI-driven methods intelligently compare images, ignoring trivial changes, thus reducing false positives. However, AI-based methods can sometimes misinterpret changes, leading to missed bugs or flaky results.
+Visual testing strategies can be categorized as pixel-perfect or AI-driven. Pixel-perfect approaches compare screenshots pixel by pixel, which can lead to false positives due to minor differences like anti-aliasing. AI-driven methods intelligently compare images, ignoring trivial changes, thus reducing false positives. However, AI-based methods can sometimes misinterpret changes, leading to missed bugs or flaky results. The right choice depends on which diff engine sits underneath — see our deep dive on [screenshot comparison algorithms](/blog/screenshot-comparison-algorithms-visual-testing/) for the trade-offs between pixelmatch, SSIM, pHash, ODiff, and AI ensembles.
 
 ### Types of Visual Testing
 
-- **Manual**: Manual visual testing involves a human visually comparing screens.
-- **Automated**: Automated testing uses tools that leverage algorithms to speed up the process of screenshot collection, often requiring manual human-based assessment. This speeds up test execution but can still be slow in assessment and may lead to missed bugs in production.
-- **Pixel-by-Pixel**: This method can be precise but is often prone to false positives.
-- **AI-Augmented Comparison**: AI-based tools can intelligently ignore minor changes but are not always perfect and may introduce flakiness or miss critical issues.
-- **AI-Augmented Querying**: This method allows questioning screenshots using AI/LLM models, such as asking, "How many products are in the cart?" or "What's the total amount?". It improves test stability while keeping it dynamic and works well when combined with other assertion types (often non-visual).
+- **Manual**: A human visually comparing screens — slow, error-prone, and impossible to scale, but still useful for one-off design reviews.
+- **Automated pixel-by-pixel**: Tools like Playwright's `toHaveScreenshot()` (powered by pixelmatch) collect screenshots and run pixel comparisons in CI. Precise, but prone to false positives from anti-aliasing and font rendering unless you containerize the runner.
+- **Structural (SSIM-based)**: Compares image patches by luminance, contrast, and structure rather than raw pixels. More forgiving of minor rendering noise; about 3× slower than pixelmatch.
+- **Perceptual hashing (pHash)**: Generates a fingerprint per image and compares hashes — used as a pre-filter to skip clearly unchanged pages before running an expensive diff.
+- **AI-augmented comparison**: Tools like Applitools Visual AI, Percy's Visual Review Agent, and Wopee.io's AI-driven diffing layer ML-based triage on top of pixel diffs, intelligently ignoring trivial changes while surfacing real regressions.
+- **AI-augmented querying**: LLM-based assertions on screenshots, e.g. "How many products are in the cart?" or "Is the CTA button visible?". Best combined with a deterministic diff engine, not used as the primary comparator.
 
 import VisualBug from './visual-bugs.webp';
 
@@ -143,20 +151,24 @@ Ensure that team members understand how to effectively use visual testing tools.
 
 ## 5. Tools and Technologies
 
-### Popular Visual Testing Tools
+### Popular Visual Testing Tools (2026)
 
-- **Applitools Eyes**: An AI-powered tool for detailed analysis across platforms, though it can be costly and lacks support post-purchase.
-- **Wopee.io**: A modern, cost-effective platform with 40-60% savings compared to competitors, offering better support and ease of use.
-- **Percy, BackstopJS**: Open-source and commercial options that vary in ease of integration and pricing.
+- **Playwright `toHaveScreenshot()`**: Built into Playwright (v1.50+ as of 2026), uses pixelmatch under the hood with YIQ color-distance and anti-aliasing detection. Baselines live in your repo. The lowest-friction starting point for most teams — see our [Playwright visual testing setup guide](/blog/getting-started-with-playwright-visual-testing/).
+- **Cypress + plugins**: Cypress 14.x doesn't ship native visual testing; teams pair it with `cypress-image-snapshot`, Percy, or Applitools.
+- **Storybook + Chromatic**: Component-level visual regression for Storybook 9.x with cloud review UX, branch-aware baselines, and Turbosnap to skip unchanged stories. Strong if you already use Storybook.
+- **Percy (BrowserStack)**: SaaS visual testing with cross-browser rendering and review workflows. Integrates with Cypress, Playwright, Selenium, Puppeteer.
+- **Applitools Eyes**: AI-powered ("Visual AI") with mature review UX and many SDKs, but enterprise pricing. Accuracy headlines are vendor-reported, not independently benchmarked — see our [Applitools alternatives breakdown](/blog/applitools-alternatives/).
+- **Wopee.io**: Modern, cost-effective AI-driven platform with self-healing baselines, multi-environment/multi-branch support, and [AI testing agents](/ai-testing-agents/) that combine visual checks with functional assertions. Typical savings of 40-60% vs. enterprise competitors. See [pricing](/pricing/).
+- **BackstopJS, Lost Pixel, Argos**: OSS-friendly options. BackstopJS is the long-standing config-driven choice; Lost Pixel and Argos modernize the workflow and increasingly back the diff engine with ODiff for speed.
 
 ### Open-Source vs. Commercial Tools
 
-Open-source tools are cost-effective but may need more manual setup. Commercial tools provide better integration and support.
+Open-source tools (Playwright's built-in, BackstopJS, Lost Pixel) are cost-effective and give you full control of the diff engine, but you'll build your own review UI, baseline storage, and branch-aware workflows. Commercial tools (Wopee.io, Applitools, Percy, Chromatic) charge for exactly that — review UX, dashboards, baseline management, and AI triage. The right answer depends on team size and reviewer fatigue, not the algorithm.
 
 ### Criteria for Tool Selection
 
-Consider your team's size, budget, and technical requirements.
-For more ideas about potential tools, check out our other blog post: [Top 5 Applitools Alternatives for Visual Testing (2024)](https://wopee.io/blog/applitools-alternatives/). You can also explore our GitHub repository for [getting started with Playwright Visual Testing](https://github.com/autonomous-testing/ws-getting-started-w-playwright-visual-testing).
+Consider your team's size, budget, technical stack (Playwright vs. Cypress vs. Storybook), CI/CD environment, number of screenshots per build, and whether reviewer fatigue is your bottleneck.
+For an in-depth comparison, see [Best Applitools Alternatives 2026](/blog/applitools-alternatives/). You can also explore our GitHub repository for [getting started with Playwright Visual Testing](https://github.com/autonomous-testing/ws-getting-started-w-playwright-visual-testing).
 
 ## 6. Implementation Strategies for Test Automation Engineers
 
@@ -277,33 +289,63 @@ Livesport, a leading provider of live sports data, adopted Wopee.io to implement
 
 To help organizations innovate their testing practices, Wopee.io offers a Pilot Project for Visual Testing. The delivery involves the Wopee.io team conducting the testing work, which aims to minimize the demand on customers' internal teams and ensure effective visual testing. Customer involvement is estimated at only 1 hour per week for regular check-ins and an additional 2 hours for ad-hoc consultation. The project begins with an onboarding workshop (2-4 hours) and ends with a closure workshop (2-4 hours). An optional workshop is also available for customers interested in understanding how visual testing works and how Wopee.io's tools operate. The project timeline is between 8 to 12 weeks and includes workshops, setup, ongoing testing, and periodic review sessions. Apart from traditional visual testing, the Wopee.io team can also combine AI-driven testing practices to further boost testing efficiency and effectiveness.
 
-## 10. Future of Visual Testing
+## 10. AI-Assisted Visual Diffing in 2026
+
+The pixel-perfect comparator era has hit its ceiling. Anti-aliasing noise, font hinting, and minor browser-engine drift produce false positives that swamp reviewers. The 2026 generation of visual testing tools layers ML-based triage on top of deterministic diffs — and a new class of fast structural and perceptual algorithms (pHash, ODiff, SSIM variants) gives that layer something better to triage.
+
+What's actually shipping:
+
+- **Perceptual hashing (pHash) pre-filters**: Generate a fingerprint per screenshot, skip the expensive comparison entirely when hashes match. Cuts CI time on large suites without changing diff fidelity on pages that did change.
+- **ODiff as a drop-in pixelmatch replacement**: Same YIQ color-distance math, same anti-aliasing detector, written in OCaml with SIMD. Argos and Lost Pixel have switched. Roughly 8× faster on the same image corpus, baselines unchanged.
+- **AI ensembles for triage**: Applitools Visual AI, Percy's Visual Review Agent, and Wopee.io's AI-driven diffing run vision models on top of a deterministic diff to classify changes as "real regression," "expected dynamic content," or "rendering noise." This is the layer that reduces reviewer load — not the comparator itself.
+- **LLM-based assertions on screenshots**: Vision-language models answer queries like "Is the cookie banner showing?" or "Are there 3 product cards visible?" Useful as a complement to pixel diffs, not a replacement. Current public benchmarks show LLMs still miss obvious changes that small CNNs detect, so don't make them your primary comparator.
+
+For a working tour of how each algorithm makes its call — and which one fits your stack — see [Screenshot Comparison Algorithms: A Visual Testing Guide](/blog/screenshot-comparison-algorithms-visual-testing/).
+
+## 11. Self-Healing Baselines
+
+Maintenance is the single biggest reason teams abandon visual testing. Every CSS tweak, design-system token change, or font swap can fail hundreds of screenshots at once. Manual mass-approval is tedious and error-prone — and the "approve all" button is how genuine regressions ship to production.
+
+Self-healing baselines are the 2026 answer. The idea borrows from [self-healing test automation](/blog/self-healing-in-sw-test-automation/) for functional tests: the system learns which kinds of changes are safe to auto-accept and which need human review.
+
+In practice this looks like:
+
+- **Intent classification**: An ML layer separates "intentional design change rolled out across the suite" (auto-update baselines) from "isolated regression on one component" (block and flag).
+- **Batch approval with grouping**: Instead of approving one screenshot at a time, group diffs by root cause (e.g., "all pages showing the new header" vs. "one button missing") and approve per group.
+- **Branch-aware baselines**: Each feature branch carries its own baseline overlay, merged only when the PR lands. No more "main is broken because someone updated baselines for their branch."
+- **Cross-environment drift detection**: Baselines tagged per environment (staging, prod, preview) catch genuine environment-specific regressions while ignoring expected differences.
+
+Tools differ in how aggressively they automate this layer. Wopee.io ships self-healing as a first-class workflow alongside its [AI testing agents](/ai-testing-agents/); Applitools' "Root Cause Analysis" and Percy's grouping are partial implementations. The principle is the same: stop treating every diff as an independent decision.
+
+## 12. Future of Visual Testing
 
 > ### "Good enough" is never good enough for your users. Visual bugs slip through traditional tests and ruin user experiences. It’s time to face the reality: visual testing is the safeguard you’ve been missing.
 
 ### Emerging Trends
 
-AI is making visual testing more robust, helping tools intelligently ignore minor changes. AI-driven comparison techniques are evolving to understand the context of visual changes better, leading to fewer false positives and missed defects.
+AI-assisted comparators (Applitools Visual AI, Percy's Visual Review Agent, Wopee.io's AI diffing) have moved from "demo features" in 2023 to default workflows in 2026. The next wave is fast structural algorithms — ODiff, pHash pre-filters, SSIM variants like `bezkrovny` in Vitest — replacing pixelmatch in OSS pipelines without changing baselines.
 
 ### Evolving Standards
 
-Visual testing tools must adapt to changes in web technologies, such as single-page applications, dynamic content, and responsive design. Evolving standards in web development will continue to drive innovation in visual testing tools, making them more adaptable and accurate.
+Visual testing tools must adapt to single-page apps, dynamic content, responsive design, and now component-driven architectures (Storybook 9, design systems, shadcn-style libraries). Component-level visual regression (Chromatic, Lost Pixel) is becoming as important as full-page screenshots, especially in monorepos where pages are assembled from dozens of versioned components.
 
 ### Integrating AI and Machine Learning
 
-The future of visual testing will increasingly leverage AI and machine learning to intelligently identify, classify, and prioritize visual changes. This will help testers focus on the most critical issues while minimizing noise.
+The future of visual testing will increasingly leverage AI and machine learning to identify, classify, and prioritize visual changes — and to drive [self-healing baselines](#11-self-healing-baselines) that auto-accept intent-classified design rollouts. Expect more ML triage layers above deterministic diff engines, and more vision-language model assertions ("does the page look like a checkout flow?") alongside pixel diffs.
 
 ### Collaboration Across Teams
 
-As visual testing matures, collaboration between development, QA, and design teams will become more critical. Future tools are expected to integrate more seamlessly with design systems, making visual testing an integral part of the entire development process, from concept to deployment.
+As visual testing matures, collaboration between development, QA, and design teams will become more critical. Future tools are expected to integrate more seamlessly with design systems and Figma tokens, making visual testing an integral part of the development process from concept to deployment.
 
 ### Preparation for the Future
 
-Stay current with new tools, practices, and AI advancements. Regularly attend conferences, join webinars, and participate in communities focused on testing automation and visual testing. Keep an eye on how emerging technologies can enhance your visual testing capabilities.
+Stay current with new tools, practices, and AI advancements. Containerize your rendering environment, audit which diff algorithm sits under your stack, and review whether reviewer fatigue (not algorithm choice) is your real bottleneck. If it is, that's when [AI testing agents](/ai-testing-agents/) and self-healing baselines pay off.
 
 ## Conclusion
 
-Visual testing is a vital complement to functional testing, ensuring that applications look as intended and provide a high-quality user experience. Whether minimizing manual UI checks or adding an extra layer of assurance, the time to invest in visual testing is now.
+Visual testing is a vital complement to functional testing, ensuring that applications look as intended and provide a high-quality user experience. In 2026, the question is no longer "should I add visual tests" but "which diff algorithm and which review workflow fit my team's scale." Start with Playwright's built-in `toHaveScreenshot()` if you're new, then layer ODiff or an AI-assisted platform like [Wopee.io](/visual-testing/) when reviewer fatigue or false-positive volume becomes the bottleneck.
+
+For deeper dives on adjacent topics, see [Playwright visual testing setup](/blog/getting-started-with-playwright-visual-testing/), [autonomous visual testing with Robot Framework](/blog/autonomous-visual-testing-with-robot-framework/), and the algorithm-level breakdown in [Screenshot Comparison Algorithms](/blog/screenshot-comparison-algorithms-visual-testing/).
 
 :::tip
 
@@ -318,3 +360,5 @@ Experience the ease and affordability of Wopee.io's Visual Regression Testing. S
 👉 Start [Your Free Trial Now](https://cmd.wopee.io/login) and see how effortless visual testing can be.
 
 :::
+
+_Last updated: May 2026._


### PR DESCRIPTION
## Summary

Refreshes [`/blog/ultimate-guide-to-visual-testing/`](https://wopee.io/blog/ultimate-guide-to-visual-testing/) — the visual-testing pillar anchor — which was flagged by Ahrefs' May 15 crawl as "Organic traffic dropped." Medium-depth refresh (~30% of body) per the agreed sprint plan.

## What changed

| Field | Before | After |
|---|---|---|
| Title (frontmatter) | `Ultimate Guide to Visual Testing` | `Ultimate Guide to Visual Testing (2026)` |
| Rendered `<title>` | 45 chars | 52 chars (≤60, comfortably under the new hard rule) |
| Description | (stale) | 156-char, primary-keyword-first, in the 80–160 SEO_RULES window |
| AIO opener | none | ~70-word direct-answer paragraph (see below) |

## AIO opener (now lives right after the H1)

> Visual testing (or visual regression testing) captures screenshots of your web app, compares them against approved baselines, and flags pixel-level or structural differences as regressions. You need it whenever CSS, fonts, layout, or third-party widgets can break the UI without breaking functional tests. The 2026 toolchain spans Playwright's built-in `toHaveScreenshot()`, Percy and Chromatic for component review, Applitools and Wopee.io for AI-assisted diffing, and engines like pixelmatch and ODiff underneath.

## Body changes (~30% of content)

- **New section**: AI-assisted diffing landscape (pixelmatch / SSIM / pHash / ODiff / AI ensembles)
- **New section**: Self-healing baselines — connects to the `/blog/self-healing-in-sw-test-automation/` pillar
- **New section**: 2026 best-practices summary
- **Year refs**: `2024`/`2025` → `2026` where claims still hold
- **Tool versions**: refreshed Playwright / Percy / Chromatic version notes
- **Intro restructure**: leads with "what is visual testing + when + tools" in the first 200 words to match search intent

## Internal links added

- `/blog/screenshot-comparison-algorithms-visual-testing/` (diff algorithms deep-dive)
- `/blog/autonomous-visual-testing-with-robot-framework/` (sibling pillar)
- `/blog/applitools-alternatives/` (tool comparison)
- `/ai-testing-agents/` (AI-assisted testing context)
- `/pricing/` (CTA)

## Why this matters

- Recovers organic traffic on the visual-testing pillar (Ahrefs Organic-traffic-dropped alert from May 15)
- Anchors the visual-testing topic cluster — paired with sibling refreshes (`/blog/getting-started-with-playwright-visual-testing/`, `/blog/autonomous-visual-testing-with-robot-framework/`, `/blog/screenshot-comparison-algorithms-visual-testing/`)
- 2026 framing + AI-assisted diffing coverage match what search intent has shifted to

## Test plan

- [x] `npx docusaurus build --no-minify` succeeds
- [x] Rendered `<title>` ≤60 chars (52)
- [x] AIO opener appears in built HTML
- [x] Existing slug preserved
- [ ] Friday May 29 Ahrefs crawl: confirm "Organic traffic dropped" alert clears