### PR TITLE
feat(home,cro): de-texted hero variant

### DIFF
--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -180,10 +180,10 @@ const HomeHeroVibe = () => {
               </div>
             </div>
 
-            {showInstructions ? (
+            {showInstructions || testingInstructions.length > 0 ? (
               <textarea
                 rows={3}
-                autoFocus
+                autoFocus={showInstructions}
                 value={testingInstructions}
                 placeholder="What should the agent test? (e.g. login, checkout, search). Leave blank to let it decide."
                 className="w-full bg-gray-50/80 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg px-3.5 py-2.5 focus:outline-none focus:border-secondary-wopee focus:ring-2 focus:ring-secondary-wopee/20 resize-none text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 transition-all"

--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -190,14 +190,21 @@ const HomeHeroVibe = () => {
                 onChange={(e) => setTestingInstructions(e.target.value)}
               />
             ) : (
-              <button
-                type="button"
+              <span
+                role="button"
+                tabIndex={0}
                 onClick={() => setShowInstructions(true)}
-                className="self-start inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 hover:text-secondary-wopee dark:hover:text-primary-wopee transition-colors"
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setShowInstructions(true);
+                  }
+                }}
+                className="hero-add-instructions self-start inline-flex items-center gap-1.5 cursor-pointer text-sm transition-colors"
               >
                 <Plus className="w-3.5 h-3.5" />
                 Add testing instructions (optional)
-              </button>
+              </span>
             )}
 
             <div className="flex justify-between items-center gap-2">

--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -167,8 +167,8 @@ const HomeHeroVibe = () => {
               <label className="text-[10px] uppercase tracking-[0.15em] text-gray-500 dark:text-gray-400 font-semibold pl-1">
                 Test environment URL
               </label>
-              <div className="group relative flex items-center gap-2.5 px-3.5 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/60 focus-within:border-secondary-wopee dark:focus-within:border-primary-wopee focus-within:ring-2 focus-within:ring-secondary-wopee/20 dark:focus-within:ring-primary-wopee/20 transition-all">
-                <SelectedIcon className="w-4 h-4 text-gray-400 dark:text-gray-500 group-focus-within:text-secondary-wopee dark:group-focus-within:text-primary-wopee transition-colors flex-shrink-0" />
+              <div className="group relative flex items-center gap-2.5 px-3.5 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/60 focus-within:border-secondary-wopee focus-within:ring-2 focus-within:ring-secondary-wopee/20 transition-all">
+                <SelectedIcon className="w-4 h-4 text-gray-400 dark:text-gray-500 group-focus-within:text-secondary-wopee transition-colors flex-shrink-0" />
                 <input
                   ref={urlInputRef}
                   type="url"
@@ -186,7 +186,7 @@ const HomeHeroVibe = () => {
                 autoFocus
                 value={testingInstructions}
                 placeholder="What should the agent test? (e.g. login, checkout, search). Leave blank to let it decide."
-                className="w-full bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 focus:outline-none focus:border-secondary-wopee dark:focus:border-primary-wopee resize-none text-sm"
+                className="w-full bg-gray-50/80 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg px-3.5 py-2.5 focus:outline-none focus:border-secondary-wopee focus:ring-2 focus:ring-secondary-wopee/20 resize-none text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 transition-all"
                 onChange={(e) => setTestingInstructions(e.target.value)}
               />
             ) : (
@@ -210,17 +210,18 @@ const HomeHeroVibe = () => {
             <div className="flex justify-between items-center gap-2">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <button
-                    type="button"
-                    className="inline-flex items-center gap-2 px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800/60 text-sm text-gray-700 dark:text-gray-200 hover:border-secondary-wopee dark:hover:border-primary-wopee transition-colors"
+                  <div
+                    role="button"
+                    tabIndex={0}
                     aria-label="Pick a sample scenario"
+                    className="hero-scenario-trigger inline-flex items-center gap-2 px-3.5 py-2.5 rounded-lg border border-solid border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/60 text-sm text-gray-700 dark:text-gray-200 hover:border-secondary-wopee transition-colors cursor-pointer select-none"
                   >
                     <SelectedIcon className="w-4 h-4" />
                     <span className="font-medium">
                       {appTemplates[appType].label}
                     </span>
                     <ChevronDown className="w-3.5 h-3.5 opacity-60" />
-                  </button>
+                  </div>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent
                   align="start"

--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -7,6 +7,8 @@ import {
   Landmark,
   ShoppingCart,
   Play,
+  Plus,
+  Sparkles,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -84,6 +86,7 @@ const HomeHeroVibe = () => {
     mode: "vibe",
   });
   const [videoOpen, setVideoOpen] = useState(false);
+  const [showInstructions, setShowInstructions] = useState(false);
   const urlInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -155,10 +158,6 @@ const HomeHeroVibe = () => {
             for Web Apps
           </span>
         </h1>
-        <h2 className="max-w-2xl text-center text-base sm:text-lg font-normal text-pretty text-gray-700 dark:text-gray-200 leading-relaxed">
-          Paste a URL. Our agents explore your app, generate Playwright tests,
-          and catch regressions before your users do.
-        </h2>
       </section>
 
       <div className="relative z-10 w-full max-w-3xl px-4">
@@ -181,13 +180,25 @@ const HomeHeroVibe = () => {
               </div>
             </div>
 
-            <textarea
-              rows={4}
-              value={testingInstructions}
-              placeholder="Testing instructions (optional) — leave blank and our agent will suggest what to test."
-              className="w-full bg-transparent border-none focus:outline-none resize-none text-sm"
-              onChange={(e) => setTestingInstructions(e.target.value)}
-            />
+            {showInstructions ? (
+              <textarea
+                rows={3}
+                autoFocus
+                value={testingInstructions}
+                placeholder="What should the agent test? (e.g. login, checkout, search). Leave blank to let it decide."
+                className="w-full bg-transparent border border-gray-200 dark:border-gray-700 rounded-lg px-3 py-2 focus:outline-none focus:border-secondary-wopee dark:focus:border-primary-wopee resize-none text-sm"
+                onChange={(e) => setTestingInstructions(e.target.value)}
+              />
+            ) : (
+              <button
+                type="button"
+                onClick={() => setShowInstructions(true)}
+                className="self-start inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400 hover:text-secondary-wopee dark:hover:text-primary-wopee transition-colors"
+              >
+                <Plus className="w-3.5 h-3.5" />
+                Add testing instructions (optional)
+              </button>
+            )}
 
             <div className="flex justify-between items-center gap-2">
               <DropdownMenu>
@@ -262,14 +273,17 @@ const HomeHeroVibe = () => {
                 className="flex items-center gap-2 px-5 py-2 font-bold rounded-lg shadow-lg shadow-purple-500/30 dark:shadow-yellow-500/30 hover:shadow-purple-500/50 dark:hover:shadow-yellow-500/50 hover:scale-105 transition-all"
                 id="vibe-testing"
               >
-                <Send />
-                <span className="text-white dark:text-black font-bold hidden sm:block">
-                  Test now!
+                <Sparkles className="w-4 h-4" />
+                <span className="text-white dark:text-black font-bold">
+                  Try it free
                 </span>
               </Button>
             </div>
           </div>
         </div>
+        <p className="mt-3 text-center text-xs text-gray-500 dark:text-gray-400">
+          No credit card · 60-second setup · Free trial
+        </p>
       </div>
 
       <HeroTrustedByStrip />

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -285,10 +285,10 @@ body.is-home .navbar-sidebar .menu__list-item .menu__list-item-collapsible {
   color: rgb(209 213 219); /* gray-300 */
 }
 .hero-add-instructions:hover {
-  color: var(--secondary-wopee);
+  color: #7030a0; /* secondary-wopee — matches form focus rings */
 }
 [data-theme="dark"] .hero-add-instructions:hover {
-  color: var(--primary-wopee);
+  color: #a78bfa; /* lighter purple, visible on dark bg */
 }
 
 /* Hero "Trusted by" marquee */

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -277,6 +277,20 @@ body.is-home .navbar-sidebar .menu__list-item .menu__list-item-collapsible {
   display: none !important;
 }
 
+/* Hero "Add testing instructions" toggle — bypass Infima's role=button color */
+.hero-add-instructions {
+  color: rgb(55 65 81); /* gray-700 */
+}
+[data-theme="dark"] .hero-add-instructions {
+  color: rgb(209 213 219); /* gray-300 */
+}
+.hero-add-instructions:hover {
+  color: var(--secondary-wopee);
+}
+[data-theme="dark"] .hero-add-instructions:hover {
+  color: var(--primary-wopee);
+}
+
 /* Hero "Trusted by" marquee */
 @keyframes hero-marquee {
   0% { transform: translateX(0); }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -284,11 +284,13 @@ body.is-home .navbar-sidebar .menu__list-item .menu__list-item-collapsible {
 [data-theme="dark"] .hero-add-instructions {
   color: rgb(209 213 219); /* gray-300 */
 }
+/* Hover follows the H1 brand emphasis pattern: secondary-wopee in light,
+   primary-wopee in dark — same colors used for "for Web Apps" highlight. */
 .hero-add-instructions:hover {
-  color: #7030a0; /* secondary-wopee — matches form focus rings */
+  color: #7030a0; /* secondary-wopee */
 }
 [data-theme="dark"] .hero-add-instructions:hover {
-  color: #a78bfa; /* lighter purple, visible on dark bg */
+  color: #ffcc00; /* primary-wopee */
 }
 
 /* Hero "Trusted by" marquee */


### PR DESCRIPTION
## Why

CRO-focused variant of the hero on top of #207, kept on a separate branch so we can A/B it (or keep/discard cleanly).

**Hypothesis:** visitors abandon when the hero asks them to read three blocks of text (badge + H1 + subtitle + multi-line textarea) before they understand what to click.

## What changes

- Drop the **subtitle** entirely — the H1 and the form already say "paste a URL"
- Collapse the **instructions textarea** behind a "+ Add testing instructions" toggle — empty multi-line fields ask for commitment users haven't made yet; this matches how Notion / Linear / OpenAI handle optional fields
- Rename **"Test now!" → "Try it free"** with a sparkles icon — the word "free" consistently lifts CTRs
- Add a **"No credit card · 60-second setup · Free trial"** reassurance line directly under the CTA, where hesitating visitors look

## Out of scope (next iterations)

Pulling Grafana + Smartlook data in parallel to inform additional variants. If the data points to the form (not the copy) being the bottleneck, we'll do a second variant that reduces fields further. Drafting an A/B plan once data is in.

## Test plan

- [ ] Hero on `/` shows: badge → H1 → form → trust line → carousel (no subtitle)
- [ ] Instructions are hidden by default; clicking "+ Add testing instructions" reveals the textarea (autofocused)
- [ ] CTA reads "Try it free" with sparkles; "No credit card · 60-second setup · Free trial" line below
- [ ] Form is still submittable with URL only (no instructions required)
- [ ] All subpages still show the full nav + footer