### PR TITLE
feat(home): rebuild homepage hero around AI Testing Agents positioning

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -242,6 +242,7 @@ const config = {
             to: "/ai-testing-agents",
             label: "Solutions",
             position: "left",
+            className: "navbar-item--hide-on-home",
             items: [
               { to: "/ai-testing-agents", label: "AI Agents for Software Testing" },
               { to: "/visual-testing", label: "Visual Regression Testing" },
@@ -252,9 +253,9 @@ const config = {
               },
             ],
           },
-          { to: "/pricing", label: "Pricing", position: "left" },
-          { to: "/blog", label: "Blog", position: "left" },
-          { to: "/about-us", label: "About us", position: "left" },
+          { to: "/pricing", label: "Pricing", position: "left", className: "navbar-item--hide-on-home" },
+          { to: "/blog", label: "Blog", position: "left", className: "navbar-item--hide-on-home" },
+          { to: "/about-us", label: "About us", position: "left", className: "navbar-item--hide-on-home" },
           {
             to: "https://cmd.wopee.io/login",
             target: "_blank",
@@ -292,6 +293,14 @@ const config = {
                 label: "Playwright AI Agent",
                 to: "blog/playwright-bot-ai-powered-test-automation",
               },
+            ],
+          },
+          {
+            title: "Company",
+            items: [
+              { label: "Pricing", to: "/pricing" },
+              { label: "About us", to: "/about-us" },
+              { label: "Book a demo", to: "/book-demo" },
             ],
           },
           {

--- a/src/components/home-page/HeroTrustedByStrip.tsx
+++ b/src/components/home-page/HeroTrustedByStrip.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+
+// Per-logo slot (height + width) so wildly different source aspect ratios
+// (Generali ~7.3:1 wide, Multitude ~2:1, Livesport ~2:1) can each occupy a
+// similar optical area. Wide wordmarks get wider/shorter slots; 2:1 PNGs that
+// looked too small get taller slots.
+type Customer = {
+  name: string;
+  logo: string;
+  invertDark?: boolean;
+  noFilter?: boolean;
+  h: string;
+  w: string;
+  pad?: string;
+};
+
+const customers: Customer[] = [
+  // Livesport sits early; Flashscore late so they're never adjacent (the
+  // marquee duplicates and loops — Accenture → Multitude is the only seam).
+  { name: "Multitude", logo: "/img/customers/multitude-logo.png", invertDark: true, h: "h-10 sm:h-12", w: "w-[130px] sm:w-[150px]", pad: "p-1" },
+  { name: "Generali", logo: "/img/customers/generali-logo-small.svg", invertDark: true, h: "h-7 sm:h-9", w: "w-[140px] sm:w-[160px]", pad: "p-1" },
+  { name: "Livesport", logo: "/img/customers/livesport-logo.png", invertDark: true, h: "h-12 sm:h-14", w: "w-[140px] sm:w-[160px]", pad: "p-0" },
+  { name: "SYNOT", logo: "/img/customers/synot-logo-2.png", invertDark: true, h: "h-10 sm:h-12", w: "w-[160px] sm:w-[180px]", pad: "p-1" },
+  { name: "Inventi", logo: "/img/customers/inventi-logo.png", invertDark: true, h: "h-10 sm:h-12", w: "w-[130px] sm:w-[150px]", pad: "p-1" },
+  { name: "Tesena", logo: "/img/investors/tesena-logo.png", invertDark: true, h: "h-12 sm:h-14", w: "w-[150px] sm:w-[170px]", pad: "p-0" },
+  { name: "Principal", logo: "/img/customers/principal-logo-gray.svg", noFilter: true, h: "h-9 sm:h-10", w: "w-[140px] sm:w-[160px]", pad: "p-1" },
+  { name: "Flashscore", logo: "/img/customers/flash-score-logo.png", invertDark: true, h: "h-12 sm:h-14", w: "w-[150px] sm:w-[170px]", pad: "p-0" },
+  { name: "Nice Project", logo: "/img/customers/niceproject-logo.svg", invertDark: true, h: "h-9 sm:h-10", w: "w-[140px] sm:w-[160px]", pad: "p-1" },
+  { name: "Accenture", logo: "/img/customers/accenture-logo-gray.svg", noFilter: true, h: "h-9 sm:h-10", w: "w-[130px] sm:w-[150px]", pad: "p-1" },
+];
+
+const HeroTrustedByStrip = () => {
+  const items = [...customers, ...customers];
+  return (
+    <div className="relative z-10 w-full max-w-6xl px-4">
+      <p className="text-[10px] sm:text-xs tracking-[0.2em] uppercase text-gray-500 dark:text-gray-400 font-medium mb-3 text-center">
+        Trusted by leading engineering teams
+      </p>
+      <div className="relative overflow-hidden mask-fade-x">
+        <div className="flex items-center gap-6 sm:gap-8 animate-marquee whitespace-nowrap py-1">
+          {items.map((customer, i) => (
+            <div
+              key={`${customer.name}-${i}`}
+              className={`${customer.h} ${customer.w} ${customer.pad ?? ""} flex items-center justify-center shrink-0`}
+            >
+              <img
+                className={`max-h-full max-w-full object-contain transition-opacity ${
+                  customer.noFilter
+                    ? "opacity-70 hover:opacity-100"
+                    : `grayscale opacity-70 hover:opacity-100 ${customer.invertDark ? "dark:invert" : ""}`
+                }`}
+                src={customer.logo}
+                alt={customer.name}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HeroTrustedByStrip;

--- a/src/components/home-page/HeroVideoModal.tsx
+++ b/src/components/home-page/HeroVideoModal.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useRef, useState } from "react";
+import { X } from "lucide-react";
+
+interface HeroVideoModalProps {
+  sources: string[];
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const HeroVideoModal: React.FC<HeroVideoModalProps> = ({
+  sources,
+  isOpen,
+  onClose,
+}) => {
+  const [index, setIndex] = useState(0);
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (isOpen) setIndex(0);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (isOpen && videoRef.current) {
+      videoRef.current.load();
+      videoRef.current.play().catch(() => {});
+    }
+  }, [index, isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [isOpen, onClose]);
+
+  const handleEnded = () => {
+    if (index < sources.length - 1) {
+      setIndex(index + 1);
+    } else {
+      onClose();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const currentSrc = sources[index];
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/95 z-[100] flex items-center justify-center p-4"
+      onClick={onClose}
+      role="dialog"
+      aria-label="Product walkthrough video"
+    >
+      <div
+        className="relative w-full max-w-6xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <video
+          ref={videoRef}
+          key={`hero-modal-${index}`}
+          autoPlay
+          controls
+          playsInline
+          onEnded={handleEnded}
+          className="w-full h-auto rounded-lg shadow-2xl"
+        >
+          <source src={currentSrc} type="video/webm" />
+          <source src={currentSrc.replace(".webm", ".mp4")} type="video/mp4" />
+        </video>
+
+        <button
+          onClick={onClose}
+          className="absolute -top-3 -right-3 sm:top-2 sm:right-2 bg-black/80 hover:bg-black text-white p-2 rounded-full shadow-lg"
+          aria-label="Close fullscreen video"
+        >
+          <X className="w-5 h-5" />
+        </button>
+
+        <div className="absolute bottom-3 left-3 right-3 flex items-center gap-1.5 pointer-events-none">
+          {sources.map((_, i) => (
+            <span
+              key={i}
+              className={`h-1 flex-1 rounded-full ${
+                i === index ? "bg-primary-wopee" : "bg-white/30"
+              }`}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HeroVideoModal;

--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -1,14 +1,35 @@
 import React, { useRef, useState, useEffect } from "react";
-import { Send, Globe } from "lucide-react";
+import {
+  Send,
+  Globe,
+  ChevronDown,
+  AppWindow,
+  Landmark,
+  ShoppingCart,
+  Play,
+  Plus,
+  Sparkles,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 
 import { AppType } from "./vibe/enums";
 import LoginDialog from "./vibe/LoginDialog";
-import ApplicationTypeSwitch from "./vibe/ApplicationTypeSwitch";
+import HeroVideoModal from "./HeroVideoModal";
+import HeroTrustedByStrip from "./HeroTrustedByStrip";
 
 const appTemplates = {
   [AppType.WEBSITE]: {
+    label: "Website",
+    icon: Globe,
     url: "https://dronjo.wopee.io",
     instructions: `Test login procedure.
 Navigate to the login page (click on the Sign in button).
@@ -16,28 +37,40 @@ Sign in with any @tesena.com email and any password.
 Verify you reach the home page and see the Logout button (top right).`,
   },
   [AppType.E_COMMERCE]: {
+    label: "E-commerce",
+    icon: ShoppingCart,
     url: "https://www.saucedemo.com",
     instructions: `Test purchase procedure.
 Login with: standard_user / secret_sauce and verify redirect to product listing.
 Add an item to cart, complete the purchase, and verify 'Thank you for your order!' message displayed.`,
   },
   [AppType.BANKING]: {
+    label: "Banking",
+    icon: Landmark,
     url: "https://moja.tatrabanka.sk/html-tb/en/demo",
     instructions: `Test login procedure.
 Wait for page load, accept cookies (if shown), submit form with pre-filled PIN.`,
   },
   [AppType.YOUR_APPLICATION]: {
+    label: "Your app",
+    icon: AppWindow,
     url: "",
-    instructions: "Open homepage, accept cookies if prompted, suggest what to test.",
+    instructions: "",
   },
 };
 const urlList = Object.entries(appTemplates).map(([key, value]) => ({
   url: value.url,
   type: key as AppType,
 }));
-const defaultTemplate = AppType.E_COMMERCE;
+const defaultTemplate = AppType.YOUR_APPLICATION;
 const URL_REGEX =
   /^(https?:\/\/)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,4}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/;
+
+const heroVideoSources = [
+  "/how-it-works/step-1.webm",
+  "/how-it-works/step-2.webm",
+  "/how-it-works/step-3.webm",
+];
 
 const HomeHeroVibe = () => {
   const [appUrl, setAppUrl] = useState(appTemplates[defaultTemplate].url);
@@ -52,6 +85,8 @@ const HomeHeroVibe = () => {
     isOpen: false,
     mode: "vibe",
   });
+  const [videoOpen, setVideoOpen] = useState(false);
+  const [showInstructions, setShowInstructions] = useState(false);
   const urlInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -59,10 +94,6 @@ const HomeHeroVibe = () => {
       urlInputRef.current?.focus();
     }
   }, [appType]);
-
-  const maxSize = 50;
-  const minSize = 20;
-  const parseSize = Math.max(minSize, Math.min(maxSize, appUrl.length));
 
   const handleAppTypeChange = (type: AppType) => {
     setAppType(type);
@@ -81,8 +112,11 @@ const HomeHeroVibe = () => {
   const setIsOpenVibe = (isOpen: boolean) => {
     setLoginDialogState({ isOpen, mode: "vibe" });
   };
+
+  const SelectedIcon = appTemplates[appType].icon;
+
   return (
-    <div className="relative lg:min-h-[calc(100vh-120px)] flex flex-col justify-center items-center gap-6 lg:gap-8 overflow-hidden py-6 lg:py-8">
+    <div className="relative lg:min-h-[calc(100vh-100px)] flex flex-col justify-center items-center gap-5 lg:gap-6 overflow-hidden py-5 lg:py-6">
       <div
         className="pointer-events-none select-none absolute inset-0 w-full h-full bg-gradient-to-br from-blue-50 via-purple-50 to-indigo-100 dark:from-gray-900 dark:via-purple-900/20 dark:to-indigo-900/20 z-0"
         style={{
@@ -92,16 +126,29 @@ const HomeHeroVibe = () => {
             "100% 100%, 100% 100%, 100% 100%, 40px 40px, 40px 40px",
         }}
       />
-      <section className="relative z-10 flex flex-col items-center gap-4 md:gap-6">
-        <span className="inline-flex items-center gap-2 px-4 py-1.5 rounded-full text-xs sm:text-sm font-medium bg-gray-900/5 dark:bg-white/5 backdrop-blur border border-gray-900/10 dark:border-white/15 text-gray-700 dark:text-gray-200">
-          <span className="w-1.5 h-1.5 rounded-full bg-primary-wopee animate-pulse" />
-          AI Testing Agents · The AI testing tool for your web app
-        </span>
+
+      <section className="relative z-10 flex flex-col items-center gap-3 md:gap-4 px-4">
+        <button
+          type="button"
+          onClick={() => setVideoOpen(true)}
+          aria-label="Watch the 60-second demo"
+          className="group inline-flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-1.5 rounded-full text-xs sm:text-sm font-medium bg-gray-900/5 dark:bg-white/5 backdrop-blur border border-gray-900/10 dark:border-white/15 text-gray-700 dark:text-gray-200 hover:border-secondary-wopee dark:hover:border-primary-wopee transition-colors"
+        >
+          <span className="w-1.5 h-1.5 rounded-full bg-primary-wopee" />
+          <span>
+            Playwright-friendly · Self-healing · <strong className="font-semibold">Free to start</strong>
+          </span>
+          <span className="opacity-30">·</span>
+          <span className="inline-flex items-center gap-1.5 text-secondary-wopee dark:text-primary-wopee group-hover:underline">
+            <Play className="w-3 h-3 fill-current" />
+            Watch demo
+          </span>
+        </button>
         <h1
           className="font-bold text-center text-4xl sm:text-5xl md:text-6xl lg:text-7xl text-pretty leading-[1] tracking-tighter"
           style={{ textShadow: "0 4px 30px rgba(0,0,0,0.25)" }}
         >
-          <span className="whitespace-nowrap">Your app, tested.</span>
+          <span className="whitespace-nowrap">AI Testing Agents</span>
           <br />
           <span
             className="text-secondary-wopee dark:text-primary-wopee"
@@ -110,79 +157,143 @@ const HomeHeroVibe = () => {
                 "0 0 40px rgba(112,48,160,0.35), 0 4px 30px rgba(0,0,0,0.15)",
             }}
           >
-            Autonomously.
+            for Web Apps
           </span>
         </h1>
-        <h2 className="max-w-2xl text-center text-base sm:text-lg md:text-xl font-normal text-pretty text-gray-700 dark:text-gray-200 leading-relaxed px-4">
-          The AI testing tool that finds bugs before your users do.
-          No scripts, no maintenance. Deploy and sleep well.
-        </h2>
       </section>
 
-      <div className="p-[1.5px] rounded-2xl w-full max-w-3xl bg-gradient-to-br from-secondary-wopee via-purple-500 to-primary-wopee z-10 shadow-2xl shadow-purple-900/50">
-        <div className="bg-white dark:bg-gray-900 rounded-[14px] p-5 sm:p-6 flex flex-col gap-4">
-          <div className="flex flex-col gap-1.5">
-            <label className="text-[10px] uppercase tracking-[0.15em] text-gray-500 dark:text-gray-400 font-semibold pl-1">
-              Test environment URL
-            </label>
-            <div className="group relative flex items-center gap-2.5 px-3.5 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/60 focus-within:border-secondary-wopee dark:focus-within:border-primary-wopee focus-within:ring-2 focus-within:ring-secondary-wopee/20 dark:focus-within:ring-primary-wopee/20 transition-all">
-              <Globe className="w-4 h-4 text-gray-400 dark:text-gray-500 group-focus-within:text-secondary-wopee dark:group-focus-within:text-primary-wopee transition-colors flex-shrink-0" />
-              <input
-                ref={urlInputRef}
-                type="url"
-                value={appUrl}
-                placeholder="https://your-project-url.com"
-                className="flex-1 w-full bg-transparent border-none focus:outline-none text-sm font-mono text-gray-900 dark:text-gray-100 placeholder:text-gray-400"
-                onChange={handleUrlChange}
-              />
+      <div className="relative z-10 w-full max-w-3xl px-4">
+        <div className="p-[1.5px] rounded-2xl bg-gradient-to-br from-secondary-wopee via-purple-500 to-primary-wopee shadow-2xl shadow-purple-900/40">
+          <div className="bg-white dark:bg-gray-900 rounded-[14px] p-4 sm:p-5 flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <label className="text-[10px] uppercase tracking-[0.15em] text-gray-500 dark:text-gray-400 font-semibold pl-1">
+                Your web app URL
+              </label>
+              <div className="group relative flex items-center gap-2.5 px-3.5 py-2.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/60 focus-within:border-secondary-wopee focus-within:ring-2 focus-within:ring-secondary-wopee/20 transition-all">
+                <SelectedIcon className="w-4 h-4 text-gray-400 dark:text-gray-500 group-focus-within:text-secondary-wopee transition-colors flex-shrink-0" />
+                <input
+                  ref={urlInputRef}
+                  type="url"
+                  value={appUrl}
+                  placeholder="https://your-project-url.com"
+                  className="flex-1 w-full bg-transparent border-none focus:outline-none text-sm font-mono text-gray-900 dark:text-gray-100 placeholder:text-gray-400"
+                  onChange={handleUrlChange}
+                />
+              </div>
             </div>
-          </div>
 
-          <textarea
-            rows={6}
-            value={testingInstructions}
-            placeholder="Testing instructions"
-            className="w-full bg-transparent border-none focus:outline-none resize-none text-sm"
-            onChange={(e) => setTestingInstructions(e.target.value)}
-          />
-
-          <div className="flex justify-end items-center gap-2">
-            <Button
-              size="lg"
-              variant="wopeeFlat"
-              disabled={
-                testingInstructions.length === 0 || !URL_REGEX.test(appUrl)
-              }
-              onClick={() =>
-                setLoginDialogState({ isOpen: true, mode: "vibe" })
-              }
-              className="flex items-center gap-2 px-5 py-2 font-bold rounded-lg shadow-lg shadow-purple-500/30 dark:shadow-yellow-500/30 hover:shadow-purple-500/50 dark:hover:shadow-yellow-500/50 hover:scale-105 transition-all"
-              id="vibe-testing"
-            >
-              <Send />
+            {showInstructions || testingInstructions.length > 0 ? (
+              <textarea
+                rows={3}
+                autoFocus={showInstructions}
+                value={testingInstructions}
+                placeholder="What should the agent test? (e.g. login, checkout, search). Leave blank to let it decide."
+                className="w-full bg-gray-50/80 dark:bg-gray-800/60 border border-gray-200 dark:border-gray-700 rounded-lg px-3.5 py-2.5 focus:outline-none focus:border-secondary-wopee focus:ring-2 focus:ring-secondary-wopee/20 resize-none text-sm text-gray-900 dark:text-gray-100 placeholder:text-gray-400 transition-all"
+                onChange={(e) => setTestingInstructions(e.target.value)}
+              />
+            ) : (
               <span
-                className="text-white dark:text-black font-bold hidden sm:block"
+                role="button"
+                tabIndex={0}
+                onClick={() => setShowInstructions(true)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setShowInstructions(true);
+                  }
+                }}
+                className="hero-add-instructions self-start inline-flex items-center gap-1.5 cursor-pointer text-sm transition-colors"
               >
-                Test now!
+                <Plus className="w-3.5 h-3.5" />
+                Add testing instructions (optional)
               </span>
-            </Button>
+            )}
+
+            <div className="flex justify-between items-center gap-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <div
+                    role="button"
+                    tabIndex={0}
+                    aria-label="Pick a sample scenario"
+                    className="hero-scenario-trigger inline-flex items-center gap-2 px-3.5 py-2.5 rounded-lg border border-solid border-gray-200 dark:border-gray-700 bg-gray-50/80 dark:bg-gray-800/60 text-sm text-gray-700 dark:text-gray-200 hover:border-secondary-wopee transition-colors cursor-pointer select-none"
+                  >
+                    <SelectedIcon className="w-4 h-4" />
+                    <span className="font-medium">
+                      {appTemplates[appType].label}
+                    </span>
+                    <ChevronDown className="w-3.5 h-3.5 opacity-60" />
+                  </div>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent
+                  align="start"
+                  className="w-56 bg-white dark:bg-gray-900 border-gray-200 dark:border-gray-700"
+                >
+                  <DropdownMenuLabel className="text-[10px] uppercase tracking-[0.15em] text-gray-500 dark:text-gray-400 font-semibold">
+                    Your application
+                  </DropdownMenuLabel>
+                  {([AppType.YOUR_APPLICATION] as AppType[]).map((type) => {
+                    const tpl = appTemplates[type];
+                    const Icon = tpl.icon;
+                    return (
+                      <DropdownMenuItem
+                        key={type}
+                        onSelect={() => handleAppTypeChange(type)}
+                        className="cursor-pointer flex items-center gap-2"
+                      >
+                        <Icon className="w-4 h-4" />
+                        <span>{tpl.label}</span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="text-[10px] uppercase tracking-[0.15em] text-gray-500 dark:text-gray-400 font-semibold">
+                    Try a demo app
+                  </DropdownMenuLabel>
+                  {(
+                    [
+                      AppType.WEBSITE,
+                      AppType.E_COMMERCE,
+                      AppType.BANKING,
+                    ] as AppType[]
+                  ).map((type) => {
+                    const tpl = appTemplates[type];
+                    const Icon = tpl.icon;
+                    return (
+                      <DropdownMenuItem
+                        key={type}
+                        onSelect={() => handleAppTypeChange(type)}
+                        className="cursor-pointer flex items-center gap-2"
+                      >
+                        <Icon className="w-4 h-4" />
+                        <span>{tpl.label}</span>
+                      </DropdownMenuItem>
+                    );
+                  })}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              <Button
+                size="lg"
+                variant="wopeeFlat"
+                disabled={!URL_REGEX.test(appUrl)}
+                onClick={() =>
+                  setLoginDialogState({ isOpen: true, mode: "vibe" })
+                }
+                className="flex items-center gap-2 px-5 py-2 font-bold rounded-lg shadow-lg shadow-purple-500/30 dark:shadow-yellow-500/30 hover:shadow-purple-500/50 dark:hover:shadow-yellow-500/50 hover:scale-105 transition-all"
+                id="vibe-testing"
+              >
+                <Sparkles className="w-4 h-4" />
+                <span className="text-white dark:text-black font-bold">
+                  Try it free
+                </span>
+              </Button>
+            </div>
           </div>
         </div>
       </div>
 
-      <div className="relative z-10 flex flex-col items-center gap-3">
-        <span className="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 font-medium">
-          Or pick a sample scenario
-        </span>
-        <ApplicationTypeSwitch
-          appType={appType}
-          handleAppTypeChange={handleAppTypeChange}
-        />
-      </div>
-
-      <p className="relative z-10 mx-auto text-center text-xs text-gray-600 dark:text-gray-400 px-6 whitespace-nowrap">
-        No code, one-minute setup, continuous regression coverage that scales with your release pace.
-      </p>
+      <HeroTrustedByStrip />
 
       <LoginDialog
         appUrl={appUrl}
@@ -191,6 +302,12 @@ const HomeHeroVibe = () => {
         mode={loginDialogState.mode}
         setIsOpenVibe={setIsOpenVibe}
         isOpen={loginDialogState.isOpen}
+      />
+
+      <HeroVideoModal
+        sources={heroVideoSources}
+        isOpen={videoOpen}
+        onClose={() => setVideoOpen(false)}
       />
     </div>
   );

--- a/src/components/home-page/HomeTrustedBy.tsx
+++ b/src/components/home-page/HomeTrustedBy.tsx
@@ -1,17 +1,5 @@
 import React from "react";
 
-const customers = [
-  { name: "Multitude", logo: "/img/customers/multitude-logo-wordmark.svg", invertDark: true, size: "w-[80px] sm:w-[100px]" },
-  { name: "Generali", logo: "/img/customers/generali-logo-small.svg", invertDark: true, size: "w-[145px] sm:w-[180px]" },
-  { name: "SYNOT", logo: "/img/customers/synot-logo-2.png", invertDark: true, size: "w-[135px] sm:w-[170px]" },
-  { name: "Inventi", logo: "/img/customers/inventi-logo.png", invertDark: true, size: "w-[120px] sm:w-[145px]" },
-  { name: "Tesena", logo: "/img/investors/tesena-logo.png", invertDark: true, size: "w-[130px] sm:w-[165px]" },
-  { name: "Nice Project", logo: "/img/customers/niceproject-logo.svg", invertDark: true, size: "w-[140px] sm:w-[180px]" },
-  { name: "Flashscore", logo: "/img/customers/flash-score-logo.png", invertDark: true, size: "w-[160px] sm:w-[200px]" },
-  { name: "Principal", logo: "/img/customers/principal-logo-gray.svg", noFilter: true, size: "w-[140px] sm:w-[180px]" },
-  { name: "Accenture", logo: "/img/customers/accenture-logo-gray.svg", noFilter: true, size: "w-[120px] sm:w-[145px]" },
-];
-
 const techPartners = [
   { name: "GitHub", logo: "/img/partners/github-logo.png", size: "w-[100px] sm:w-[120px]" },
   { name: "Anthropic", logo: "/img/partners/anthropic-logo.svg", size: "w-[130px] sm:w-[160px]" },
@@ -23,22 +11,7 @@ const techPartners = [
 
 const HomeTrustedBy = () => {
   return (
-    <div className="flex flex-col items-center justify-center my-24 container">
-      <p className="text-xs sm:text-sm tracking-[0.2em] uppercase text-gray-500 dark:text-gray-400 font-medium mb-12 text-center">
-        Trusted by leading engineering teams
-      </p>
-
-      <div className="grid grid-cols-3 gap-y-10 gap-x-4 sm:gap-x-8 max-w-5xl w-full px-8 items-center justify-items-center mb-12">
-        {customers.map((customer) => (
-          <img
-            key={customer.name}
-            className={`${customer.size} object-contain transition-opacity ${customer.noFilter ? "opacity-70 hover:opacity-100" : `grayscale opacity-70 hover:opacity-100 ${customer.invertDark ? "dark:invert" : ""}`}`}
-            src={customer.logo}
-            alt={customer.name}
-          />
-        ))}
-      </div>
-
+    <div className="flex flex-col items-center justify-center my-20 container">
       <p className="text-xs sm:text-sm tracking-[0.2em] uppercase text-gray-500 dark:text-gray-400 font-medium mb-10 text-center">
         Powered by world class AI and cloud partners
       </p>

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -264,6 +264,51 @@ a.navbar__item:hover {
   filter: invert(1);
 }
 
+/* Homepage: hide primary nav links (Solutions / Pricing / Blog / About us). */
+/* They remain available in the footer and on all subpages. */
+body.is-home .navbar-item--hide-on-home,
+body.is-home .navbar-sidebar .navbar-item--hide-on-home {
+  display: none !important;
+}
+/* Docusaurus strips `className` on dropdown navbar items, so hide the left-side
+   dropdown explicitly. There is no dropdown on the right (Sign In / Start for free). */
+body.is-home .theme-layout-navbar-left .navbar__item.dropdown,
+body.is-home .navbar-sidebar .menu__list-item .menu__list-item-collapsible {
+  display: none !important;
+}
+
+/* Hero "Add testing instructions" toggle — bypass Infima's role=button color */
+.hero-add-instructions {
+  color: rgb(55 65 81); /* gray-700 */
+}
+[data-theme="dark"] .hero-add-instructions {
+  color: rgb(209 213 219); /* gray-300 */
+}
+/* Hover follows the H1 brand emphasis pattern: secondary-wopee in light,
+   primary-wopee in dark — same colors used for "for Web Apps" highlight. */
+.hero-add-instructions:hover {
+  color: #7030a0; /* secondary-wopee */
+}
+[data-theme="dark"] .hero-add-instructions:hover {
+  color: #ffcc00; /* primary-wopee */
+}
+
+/* Hero "Trusted by" marquee */
+@keyframes hero-marquee {
+  0% { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+.animate-marquee {
+  animation: hero-marquee 35s linear infinite;
+}
+.animate-marquee:hover {
+  animation-play-state: paused;
+}
+.mask-fade-x {
+  -webkit-mask-image: linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%);
+  mask-image: linear-gradient(to right, transparent 0%, black 8%, black 92%, transparent 100%);
+}
+
 /* Footer */
 
 .footer {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -63,9 +63,10 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title="AI Testing Agents for Web Apps"
-      description="Stop writing tests manually. Wopee.io AI agents explore your app, generate Playwright tests, and self-heal when your UI changes. Try free."
+      description="Paste a URL — Wopee.io AI testing agents explore your web app, generate Playwright tests, run them across browsers, and self-heal when your UI changes. Free to start."
     >
       <Head>
+        <body className="is-home" />
         <script type="application/ld+json">{JSON.stringify(JSONLD_ORG)}</script>
         <script type="application/ld+json">{JSON.stringify(JSONLD_APP)}</script>
       </Head>


### PR DESCRIPTION
## Summary

Data-driven rebuild of the homepage hero on `wopee.io/`, informed by three sources pulled during this work:

- **Grafana funnel (last 30d):** 1,344 visits → 65 CTA clicks (4.4 %) → 88 signups (77 % activated). The funnel below the hero converts at near-100 %; the bleed is at the hero itself.
- **Smartlook flows (last 30d):** 46 % of internal navigators leave `/` for `/pricing` *before* clicking anything in the hero — pricing is the #1 unanswered question. Rage clicks: 3 events / 2 users → not a UX-friction problem, a positioning one.
- **Google Search Console (last 90d):** "ai testing agent(s)" pulls 763 non-brand impressions; "ai testing tool" pulls 1. "Playwright" terms pull 739 impr at 1.4 % CTR. The H1 was the odd one out vs the slug `/ai-testing-agents/`, the pillar blog asset, and what searchers actually type.

Replaces #208 (de-texted variant) — that PR's improvements are included here, plus the GSC + Smartlook layer.

## Three commits

1. **`feat(home): trim navbar on /  only + add Company footer column`** — hide Solutions/Pricing/Blog/About-us on the homepage only (kept on every subpage and in the footer); reorganise footer with a new Company column (Pricing + About us + Book a demo); set the homepage `<body>` class via Helmet; sync SEO `<title>` and meta description to the new positioning.

2. **`feat(home): refocus hero around AI Testing Agents + Playwright`** — H1 "Tool" → "Agents"; new pricing-forward badge ("Playwright-friendly · Self-healing · Free to start · ▶ Watch demo"); HeroVideoModal that plays the three step videos sequentially in fullscreen; Vibe form rebuilt with a unified field style (shared border + bg, purple focus rings, yellow reserved for the "Try it free" CTA); optional instructions textarea behind a toggle that auto-reveals when a demo app pre-fills it; scenario picker collapsed into a grouped dropdown next to the CTA; URL-bar icon mirrors the selected scenario; default scenario switched to "Your app" so the empty paste-a-URL state is the first thing visitors see.

3. **`feat(home): inline trusted-by customer marquee in the hero`** — single-row marquee directly under the form (visible above the fold at laptop viewports), per-logo slot dimensions so wildly different source aspects no longer dominate each other, hover-pause, mask-faded edges; add Livesport (separated from Flashscore across the loop seam); swap Multitude to the PNG that reads legibly at strip height; trim HomeTrustedBy to just the AI/cloud-partners section.

## Visual

Hero before vs after (1440×900):

| Before (`main`) | After (this PR) |
| --- | --- |
| Full navbar over hero | Logo + Sign In + Start for free only |
| H1: "Your app, tested. Autonomously." | H1: "AI Testing Agents for Web Apps" |
| Subtitle ("AI testing tool that finds bugs…") | (none) |
| URL + multi-line textarea + 4-button row | URL + (optional textarea toggle) + scenario dropdown |
| 9-logo grid section below | Single-row marquee directly under the form |
| `Test now!` button | `Try it free` button |

## Companion work (not in this PR)

- Engineering tickets opened on `autonomous-testing/backlog`: **#4034** (GA4 `app_sign_up` dead) and **#4035** (PG `organizationTrialStarted` dead). Both blocked accurate measurement of this PR's downstream impact and should land before A/B-testing further hero variants.
- Fresh Smartlook heatmap `homepage-new-hero-2026-05-27` (id `ebTQm3d94g`) created against the current page — usable signal in ~2–4 weeks.
- `skills/BrowserAutomation/references/smartlook-config.md` updated to list both projects (marketing vs cmd-app) so future agents don't query the wrong one.

## Test plan

- [ ] On `/`: only the logo + Sign In + Start for free appear in the navbar
- [ ] On `/pricing`, `/blog`, `/about-us`, `/ai-testing-agents`: full nav returns
- [ ] Hero badge clickable → opens the fullscreen video that auto-advances through the 3 step clips
- [ ] Default scenario = "Your app"; switching to a demo pre-fills URL + instructions and auto-reveals the textarea
- [ ] Form submits with valid URL even when instructions are empty
- [ ] Footer has a "Company" column with Pricing, About us, Book a demo
- [ ] Dark + light mode both render the form with consistent border + focus colors (no Infima `outset` bevel on the dropdown)