### PR TITLE
a11y: fix homepage accessibility issues

### DIFF
--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -133,7 +133,6 @@ const HomeHeroVibe = () => {
         <button
           type="button"
           onClick={() => setVideoOpen(true)}
-          aria-label="Watch the 60-second demo"
           className="group inline-flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-1.5 rounded-full text-xs sm:text-sm font-medium bg-gray-900/5 dark:bg-white/5 backdrop-blur border border-gray-900/10 dark:border-white/15 text-gray-700 dark:text-gray-200 hover:border-secondary-wopee dark:hover:border-primary-wopee transition-colors"
         >
           <span className="w-1.5 h-1.5 rounded-full bg-primary-wopee" />
@@ -197,6 +196,7 @@ const HomeHeroVibe = () => {
                   <>
                     <textarea
                       rows={3}
+                      aria-label="Testing instructions"
                       autoFocus={showInstructions}
                       value={testingInstructions}
                       placeholder={

--- a/src/components/home-page/HomeSocialProof.tsx
+++ b/src/components/home-page/HomeSocialProof.tsx
@@ -137,9 +137,10 @@ const TestimonialSwitcher = ({
   return (
     <div className="flex justify-center gap-2 mt-8">
       {testimonials.map((_, index) => (
-        <div
+        <button
           key={index}
-          className={`w-3 h-3 ${
+          type="button"
+          className={`appearance-none border-0 p-0 w-3 h-3 ${
             activeItemIndex === index
               ? "bg-secondary-wopee dark:bg-primary-wopee"
               : "bg-gray-300 dark:bg-gray-600 opacity-50"

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -376,7 +376,7 @@ body.is-home .navbar-sidebar .menu__list-item .menu__list-item-collapsible {
   color: rgb(75 85 99); /* gray-600 — light-mode contrast on white bg */
 }
 [data-theme="dark"] .hero-add-instructions {
-  color: rgb(107 114 128); /* gray-500 */
+  color: rgb(156 163 175); /* gray-400 — 4.5:1+ on the gray-900 form bg */
 }
 /* Hover follows the H1 brand emphasis pattern: secondary-wopee in light,
    primary-wopee in dark — same colors used for "for Web Apps" highlight. */


### PR DESCRIPTION
## Why

[PageSpeed (mobile)](https://pagespeed.web.dev/analysis/https-wopee-io/62mw3vmepb?form_factor=mobile) scores Accessibility **90**, with four failing audits — all on the homepage hero/social-proof.

## Fixes

| Audit | Issue | Fix |
|---|---|---|
| **Color contrast** | "Add testing instructions" hint was `gray-500` on the `gray-900` form (3.66:1, dark mode) | → `gray-400` (4.5:1+) |
| **Form elements have labels** | the instructions `<textarea>` had no accessible name | added `aria-label="Testing instructions"` |
| **Label/name mismatch** | watch-demo button's `aria-label` ("Watch the 60-second demo") didn't contain its visible text | removed the redundant `aria-label` so the name derives from visible content |
| **Prohibited ARIA attribute** | testimonial pager dots were `<div aria-label>` with no role (and not keyboard-operable) | changed to `<button type="button">` |

Visual appearance is unchanged; the dots are now also focusable/keyboard-operable.

## Notes

Independent of #214 (image weight). Remaining PageSpeed best-practices items (HubSpot third-party cookies, deprecation warnings) are vendor-side and out of scope.