### PR TITLE
ci: retry GitHub Pages deploy on transient in-progress collision

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment.outputs.page_url || steps.deployment_retry.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -63,4 +63,18 @@ jobs:
           path: "./build"
       - name: Deploy to GitHub Pages
         id: deployment
+        uses: actions/deploy-pages@v5
+        # The Pages backend finalizes a deployment asynchronously after the
+        # action returns, so a deploy that closely follows another can hit
+        # "due to in progress deployment" (HTTP 400). Don't fail the job yet —
+        # wait for the previous deployment to clear and retry once.
+        continue-on-error: true
+
+      - name: Wait for the previous Pages deployment to clear
+        if: steps.deployment.outcome == 'failure'
+        run: sleep 60
+
+      - name: Deploy to GitHub Pages (retry)
+        id: deployment_retry
+        if: steps.deployment.outcome == 'failure'
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Problem

\`website-demo\`'s deploy for #215 ([run 26650668864](https://github.com/autonomous-testing/website-demo/actions/runs/26650668864)) failed at the **Deploy to GitHub Pages** step (the build passed):

> Error: Failed to create deployment (status: 400) … Deployment request failed for \`7b5ae33\` (#215) due to in progress deployment. Please cancel \`026acd0\` (#214) first or wait for it to complete.

#214 and #215 merged ~14 min apart. \`actions/deploy-pages\` completes the workflow step once it *creates* a deployment, but GitHub's Pages backend finalizes asynchronously — so #214's deployment was still "in progress" on GitHub's side when #215 tried to create its own, returning HTTP 400. #216 then deployed cleanly once the stuck one cleared, so staging was never actually broken.

The existing \`concurrency: group: "pages"\` guard serializes *workflow runs* but can't observe the backend's async finalization, so it can't prevent this.

## Fix

Tolerate the transient collision instead of going red:
1. First deploy attempt runs with \`continue-on-error: true\`.
2. If it failed, \`sleep 60\` to let the previous deployment finalize.
3. Retry the deploy once — its result determines the job status.

\`environment.url\` falls back to the retry step's \`page_url\`. No change to the concurrency group, and this is safe for all three repos sharing this workflow (website / website-demo / website-prod).

## Note

This is infra resilience, not a code bug — nothing needs re-running; #216 already deployed successfully.