### PR TITLE
seo: shorten meta descriptions over 155 chars (#201)

### DIFF
--- a/blog/2024-07-10-applitools/index.md
+++ b/blog/2024-07-10-applitools/index.md
@@ -1,7 +1,7 @@
 ---
 slug: applitools
 title: "Applitools vs Wopee.io: Pricing, Features, and AI Compared"
-description: "Applitools vs Wopee.io: Applitools starts at $399/mo with complex setup. Wopee.io starts free with AI-powered autonomous testing and Playwright integration."
+description: "Applitools vs Wopee.io: Applitools starts at $399/mo with complex setup. Wopee.io starts free with AI-powered autonomous testing and Playwright support."
 authors: marcel
 tags: [visual testing, test automation, visual regression testing]
 image: ./wopee-io-easy.png

--- a/blog/2024-09-16-getting-started-w-wopee-io/index.md
+++ b/blog/2024-09-16-getting-started-w-wopee-io/index.md
@@ -1,7 +1,7 @@
 ---
 slug: getting-started-w-wopee-io-automation
 title: "Getting Started with Wopee.io: No-Code Testing"
-description: "Get started with Wopee.io in minutes — no coding required. Learn how to automate web app testing with AI, from account setup to your first autonomous test run."
+description: "Get started with Wopee.io in minutes, no coding required. Automate web app testing with AI, from account setup to your first autonomous test run."
 authors: marcel
 tags: [playwright, automation, testing, AI]
 image: ./wopee-io-3-pillars.png

--- a/blog/2024-09-25-top-5-applitools-alternatives-for-visual-testing/index.md
+++ b/blog/2024-09-25-top-5-applitools-alternatives-for-visual-testing/index.md
@@ -1,7 +1,7 @@
 ---
 slug: applitools-alternatives
 title: "Applitools Alternatives 2026: Pricing Comparison"
-description: "Honest 2026 comparison of the top Applitools alternatives — Wopee.io, Percy, Chromatic, Playwright, LambdaTest, BackstopJS — with side-by-side pricing and features."
+description: "Honest 2026 comparison of top Applitools alternatives — Wopee.io, Percy, Chromatic, Playwright, LambdaTest, BackstopJS — pricing and features compared."
 authors: marcel
 tags: [visual testing, test automation, visual regression testing]
 image: ./visual-bugs.webp

--- a/blog/2024-10-17-ultimate-guide-to-visual-testing/index.md
+++ b/blog/2024-10-17-ultimate-guide-to-visual-testing/index.md
@@ -1,7 +1,7 @@
 ---
 slug: ultimate-guide-to-visual-testing
 title: "Ultimate Guide to Visual Testing (2026)"
-description: "2026 guide to visual testing: how visual regression testing works, when to use it, and which tools (Playwright, Percy, Applitools, Wopee.io) fit modern CI/CD."
+description: "2026 guide to visual testing: how visual regression testing works, when to use it, and which tools (Playwright, Percy, Applitools, Wopee.io) fit CI/CD."
 authors: marcel
 tags: [visual testing, test automation, visual regression testing]
 image: ./visual-bugs.webp

--- a/src/pages/gdpr/index.md
+++ b/src/pages/gdpr/index.md
@@ -1,6 +1,6 @@
 ---
 title: Data Processing Agreement
-description: Data Processing Agreement between wopee labs s.r.o. and Wopee.io clients. GDPR-compliant terms covering personal data handling, subprocessors, and security.
+description: Data Processing Agreement between wopee labs s.r.o. and Wopee.io clients. GDPR-compliant terms for personal data handling, subprocessors, and security.
 custom_edit_url: null
 ---
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -63,7 +63,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title="AI Testing Agents for Web Apps"
-      description="Paste a URL — Wopee.io AI testing agents explore your web app, generate Playwright tests, run them across browsers, and self-heal when your UI changes. Free to start."
+      description="Paste a URL — Wopee.io AI agents explore your web app, generate Playwright tests, run them across browsers, and self-heal when the UI changes. Start free."
     >
       <Head>
         <body className="is-home" />

--- a/src/pages/terms-and-conditions/index.md
+++ b/src/pages/terms-and-conditions/index.md
@@ -1,6 +1,6 @@
 ---
 title: General Terms and Conditions for provision of testing services concerning Wopee platform
-description: General Terms and Conditions governing use of the Wopee platform, subscriptions, and the contractual relationship between wopee labs s.r.o. and its clients.
+description: General Terms and Conditions for use of the Wopee platform and subscriptions, governing the relationship between wopee labs s.r.o. and its clients.
 ---
 
 # General Terms and Conditions for provision of testing services concerning Wopee platform

--- a/src/pages/visual-testing/index.tsx
+++ b/src/pages/visual-testing/index.tsx
@@ -7,7 +7,7 @@ export default function LandingHome() {
   return (
     <Layout
       title="Visual Regression Testing | Wopee.io"
-      description="Automated visual regression testing for web applications. Detect UI regressions across browsers and screen sizes with AI-powered pixel-by-pixel comparisons."
+      description="Automated visual regression testing for web apps. Detect UI regressions across browsers and screen sizes with AI-powered pixel-by-pixel comparisons."
     >
       <LandingPage />
     </Layout>


### PR DESCRIPTION
Shortens 8 meta descriptions that exceeded the ~155 char SERP limit (truncated snippets were contributing to the organic CTR regression). Each keeps its primary keyword and value prop. Refs #201.

Files changed (before → after chars):

- blog/2024-07-10-applitools/index.md — 156 → 152
- blog/2024-10-17-ultimate-guide-to-visual-testing/index.md — 158 → 151
- blog/2024-09-16-getting-started-w-wopee-io/index.md — 159 → 145
- blog/2024-09-25-top-5-applitools-alternatives-for-visual-testing/index.md — 164 → 151
- src/pages/gdpr/index.md — 156 → 151
- src/pages/terms-and-conditions/index.md — 156 → 147
- src/pages/index.tsx (`<Layout description>`) — 166 → 154
- src/pages/visual-testing/index.tsx (`<Layout description>`) — 156 → 148

noindex/nofollow review: all occurrences are intentional (blog tag pages via src/theme/Root.tsx; utility/author/legal pages: book-demo, onboarding, ux, jan-beranek, marcel, gdpr). No accidental directives on indexable pages — no changes made.

`yarn build` passes (client + server compiled successfully, exit 0).