### PR TITLE
content: 2026 refresh + internal links for page-2 posts (#222)

### DIFF
--- a/blog/2024-05-08-getting-started-w-playwright-visual-testing/index.md
+++ b/blog/2024-05-08-getting-started-w-playwright-visual-testing/index.md
@@ -244,7 +244,7 @@ Maintaining a large set of baseline screenshots can become cumbersome. As your a
 
 ### 2. Flaky Tests Due to Visual Inconsistencies
 
-Certain web application elements may exhibit slight visual inconsistencies due to factors like dynamic content loading, third-party library behavior, or browser rendering differences. These inconsistencies can trigger false positives in your visual tests, leading to flaky test results.
+Certain web application elements may exhibit slight visual inconsistencies due to factors like dynamic content loading, third-party library behavior, or browser rendering differences. These inconsistencies can trigger false positives in your visual tests, leading to flaky test results. The functional equivalent of this problem — selectors breaking on UI changes — is handled by [self-healing test automation](/blog/self-healing-in-sw-test-automation/), and the same teams usually want both.
 
 **Strategies for Handling Flaky Tests:**
 

--- a/blog/2024-07-23-self-healing-in-sw-test-automation/index.md
+++ b/blog/2024-07-23-self-healing-in-sw-test-automation/index.md
@@ -18,6 +18,14 @@ Enter self-healing test automation - a game-changing approach that promises to r
 ![Self Healing in Test Automation](./self-healing-explained.jpg)
 _Source: Wopee.io & leonardo.ai._
 
+:::info 2026 update
+
+Two things changed since we first published this. First, the locator-fallback approach below (try ID, then name, then XPath) is now the floor, not the ceiling — most teams that care about maintenance have moved to LLM- or vision-based healing that resolves an element from intent ("the Submit button") rather than a fixed list of candidate selectors. Second, "self-healing" stopped being a standalone product and became a feature bundled into broader [AI testing agents](/ai-testing-agents/) that also generate and run the tests.
+
+So we have rewritten the comparison section below to reflect what the leading approaches actually do in 2026 — including a side-by-side table of Wopee.io, Healenium, Testim, and Mabl — and added an honest note on where each one breaks. The deterministic code samples further down still hold: they are the simplest way to understand the mechanics before you reach for an AI layer.
+
+:::
+
 ## Understanding Self-Healing Test Automation
 
 ### What is Self-Healing Test Automation?
@@ -135,23 +143,46 @@ Some teams implement even more advanced recovery mechanisms, such as moving test
 
 ## Tools and Frameworks for Self-Healing Automation
 
-There are numerous tools and frameworks offering self-healing capabilities in test automation. Below are a few examples, though many more options are available:
+There are numerous tools and frameworks offering self-healing capabilities. They fall into three rough camps, and the camp matters more than the brand name:
 
-### 1. Selenium with Self-Healing Extensions
+1. **Open-source libraries** that bolt healing onto an existing framework (Healenium for Selenium).
+2. **Commercial low-code platforms** that own the whole authoring + execution + healing loop (Testim, Mabl, Katalon, Ranorex).
+3. **AI agents** that generate the tests in the first place and heal them as a side effect (Wopee.io, and the broader category of [AI testing agents](/ai-testing-agents/)).
 
-Selenium, a popular open-source testing framework, can be enhanced with self-healing capabilities through various libraries and plugins like Selenium IDE (Google Chrome extension) or healenium.io. These extensions integrate with existing Selenium test suites, offering flexibility and customization. Playwright and Cypress users typically reach for AI-driven layers instead — for Playwright, our [Playwright Bot](/blog/playwright-bot-ai-powered-test-automation/) regenerates failing locators on the fly so you do not maintain selectors manually.
+### Wopee.io vs Healenium vs Testim vs Mabl
 
-### 2. Testim
+The honest comparison most vendor pages skip: every tool here heals locators, so the differentiators are *how* it picks the replacement element, *how much* of your maintenance it actually removes, and whether it also covers **visual** regressions (which locator-healing does nothing for). Here is how the four most-asked-about options line up.
 
-Testim is an AI-driven test automation platform that incorporates self-healing to automatically adjust to changes in the application UI. It features an easy-to-use interface with low-code/no-code options and advanced machine learning algorithms for UI change prediction.
+| | **Wopee.io** | **Healenium** | **Testim** | **Mabl** |
+|---|---|---|---|---|
+| **Approach to locator self-healing** | LLM + vision: regenerates the locator from page intent and a visual snapshot, not a fixed fallback list | ML similarity scoring over a stored locator history; picks the closest DOM match above a threshold | Multi-attribute "Smart Locators" weighted by ML; learns which attributes are stable across runs | ML model scores candidate elements using DOM + context; auto-applies high-confidence matches |
+| **Framework / runtime** | Generates **Playwright** code you own and run in your own CI ([Playwright Bot](/blog/playwright-bot-ai-powered-test-automation/)) | Selenium / Appium only; runs as a proxy + backend you host | Proprietary cloud runner; exports are limited | Proprietary cloud runner |
+| **Maintenance burden removed** | High — tests are regenerated, not just patched, so flow changes heal too, not only selectors | Medium — heals selectors well; new flows and assertions are still hand-authored | Medium-high — strong selector healing; logic changes need manual edits in the editor | Medium-high — strong selector healing; auto-suggests fixes for review |
+| **Visual testing** | Built-in autonomous [visual regression](/blog/getting-started-with-playwright-visual-testing/) with baseline review, not a separate tool | None — locator healing only; pair it with a visual tool | Add-on visual validation | Built-in visual testing |
+| **Hosting** | SaaS, free tier to try | Self-hosted (you run the backend) | SaaS | SaaS |
+| **Best fit** | Teams who want Playwright they control + self-healing + visual in one agent | Selenium shops wanting open-source healing without changing tools | Low-code teams standardizing on one commercial platform | Teams wanting an all-in-one cloud platform with strong reporting |
 
-### 3. Ranorex
+A few caveats worth stating plainly:
 
-Ranorex is a comprehensive test automation tool that includes self-healing features to handle dynamic UI changes. It is robust and feature-rich, supporting extensive platforms and integrating well with CI/CD tools.
+- **Locator healing and visual testing are different problems.** Healenium and most "self-healing" libraries heal *selectors* — they do nothing if a button moves, changes color, or overlaps another element. Catching that needs [visual regression testing](/blog/getting-started-with-playwright-visual-testing/) running alongside. Tools that bundle both (Wopee.io, Mabl, Testim's add-on) save you wiring two systems together.
+- **Self-hosted vs SaaS is a real cost.** Healenium is free but you run and maintain its backend and database. The commercial tools trade that for a subscription and a closed runner.
+- **"Heals the test" beats "heals the selector."** The further-down code samples patch a *locator*. An agent that regenerates the whole test (the flow plus assertions) absorbs a wider class of UI changes — which is why test *generation* and self-healing increasingly ship as one product rather than two.
 
-### 4. Katalon Studio
+### Healenium (open-source, Selenium)
 
-Katalon Studio is an integrated test automation tool with self-healing features. It is cost-effective, supports both web and mobile testing, and provides integrated test management and reporting.
+[Healenium](https://healenium.io/) is the reference open-source option. It stores a history of every locator it has seen and, when one breaks, uses ML similarity scoring to pick the closest current DOM element. It integrates cleanly with existing Selenium/Appium suites but runs as a proxy plus a backend you host yourself, and it heals selectors only — not visual or flow changes.
+
+### Testim
+
+Testim is an AI-driven low-code platform whose "Smart Locators" weight multiple element attributes and learn which ones stay stable across runs. Strong selector healing and an approachable editor; the trade-off is a proprietary cloud runner with limited export, so you do not own the test code the way you do with Playwright.
+
+### Mabl
+
+Mabl is an all-in-one cloud platform that combines ML-based locator healing with built-in visual testing and solid reporting. High-confidence repairs auto-apply; lower-confidence ones queue for review. Good fit if you want one managed product end-to-end and are comfortable with a closed runner.
+
+### Selenium with Healenium, and where Playwright/Cypress differ
+
+Selenium remains the framework with the deepest self-healing tooling (Healenium, Testim, Katalon, Ranorex all started there). Playwright and Cypress users typically reach for AI-driven layers instead — for Playwright, our [Playwright Bot](/blog/playwright-bot-ai-powered-test-automation/) regenerates failing locators on the fly so you do not maintain selectors manually, and exports runnable Playwright you keep.
 
 ## Implementing Self-Healing in Your Test Suite
 

--- a/blog/2024-08-12-predictive-test-selection/index.md
+++ b/blog/2024-08-12-predictive-test-selection/index.md
@@ -230,7 +230,7 @@ Test impact analysis (TIA) is deterministic: it maps code coverage to tests and 
 
 ### Which tools support predictive test selection?
 
-Launchable, Appsurify TestBrain, Sealights, and Orangebeard's Auto Test Pilot are the dedicated PTS vendors covered above. Bazel-based monorepos at Google, Meta, and Uber run in-house variants. For teams already on AI-driven test platforms, prioritization is increasingly a feature rather than a separate product — Wopee.io's [AI testing agents](/ai-testing-agents/) include risk-based execution alongside [self-healing](/blog/self-healing-in-sw-test-automation/), so you do not run two separate services.
+Launchable, Appsurify TestBrain, Sealights, and Orangebeard's Auto Test Pilot are the dedicated PTS vendors covered above. Bazel-based monorepos at Google, Meta, and Uber run in-house variants. For teams already on AI-driven test platforms, prioritization is increasingly a feature rather than a separate product — Wopee.io's [AI testing agents](/ai-testing-agents/) include risk-based execution alongside [self-healing](/blog/self-healing-in-sw-test-automation/) and AI test generation via [Playwright Bot](/blog/playwright-bot-ai-powered-test-automation/), so you do not run two separate services.
 
 ### When does predictive test selection actually pay off?
 

--- a/blog/2024-09-12-playwright-bot/index.md
+++ b/blog/2024-09-12-playwright-bot/index.md
@@ -103,7 +103,8 @@ In the video above, you’ll see exactly how to use Playwright Bot to automatica
 
 - **Speed and Efficiency:** Playwright Bot drastically reduces the time spent manually writing and maintaining tests.
 - **Scalability:** Effortlessly extend your test coverage for new features, without reinventing the wheel.
-- **Error Reduction:** By leveraging AI, the generated tests adapt to changes in the UI or code, reducing the likelihood of errors.
+- **Error Reduction:** By leveraging AI, the generated tests adapt to changes in the UI or code, reducing the likelihood of errors. This is the same [self-healing](/blog/self-healing-in-sw-test-automation/) principle applied at generation time — instead of patching a broken selector, the bot regenerates the flow.
+- **Visual coverage included:** Beyond functional flows, the generated suite can capture screenshots for [visual regression testing](/blog/getting-started-with-playwright-visual-testing/), so layout breaks get caught alongside logic errors.
 
 ## Upcoming Features
 

--- a/blog/2024-12-19-ai-testing-agents/index.md
+++ b/blog/2024-12-19-ai-testing-agents/index.md
@@ -79,6 +79,29 @@ _Image Source: Generated using DALL·E by OpenAI.._
   ]
 }) }} />
 
+## What Actually Works in 2026 (and What Still Doesn't)
+
+:::info 2026 update
+
+This post originally framed AI testing agents as a "revolution vs. hype" debate. A year on, the debate is mostly settled in practice — some capabilities are now boring and dependable, others are still demo-ware. Here is the honest split, based on what we ship and what customers run in CI every day.
+
+:::
+
+**What works reliably today:**
+
+- **Autonomous test generation from a URL.** Point an agent at a page and it derives flows and emits runnable tests. Our [Playwright Bot](/blog/playwright-bot-ai-powered-test-automation/) does exactly this and outputs Playwright you own.
+- **Self-healing of broken locators.** Regenerating a selector — or the whole flow — when the UI shifts is dependable enough to trust in CI. See our deep dive on [self-healing test automation](/blog/self-healing-in-sw-test-automation/) for how it works and how the tools compare.
+- **Visual regression with smart filtering.** Catching real visual diffs while ignoring anti-aliasing noise is a solved-enough problem. Start with the fundamentals in our [Playwright visual testing guide](/blog/getting-started-with-playwright-visual-testing/).
+- **Risk-based test prioritization.** Running the tests most likely to fail first — [predictive test selection](/blog/predictive-test-selection/) — is a feature inside most serious agents now, not a separate product.
+
+**What is still hype in 2026:**
+
+- **Full end-to-end QA replacement.** Agents do not own test strategy, acceptance criteria, or "is this actually correct" judgement.
+- **Reliable root-cause diagnosis.** Agents flag *what* changed well; *why* it broke still needs a human.
+- **Complex multi-step business logic without supervision.** Multi-actor flows, money movement, and stateful wizards still need human authoring and review.
+
+The practical takeaway: do not try to replace your whole suite. Replace its most brittle, most repetitive layer — usually visual regression or login/checkout coverage — let an agent own that, and expand only once you trust the results.
+
 ## What Are AI Agents?
 
 An AI agent is a software program that acts autonomously to achieve specific goals. These agents can take many forms and perform a wide range of tasks. The term "AI agent" often describes software that replaces human workers or teams by automating specific tasks or entire workflows. They’re seen as a critical evolution in software technology, redefining how businesses approach operational efficiency.
@@ -134,7 +157,9 @@ AI Testing Agents are autonomous or semi-autonomous systems that leverage artifi
 - **Visual Testing Agents**: Tools like Applitools, Percy, or Wopee.io that focus on pixel-perfect [visual verification](/visual-testing/), ensuring a seamless user experience.
 - **Exploratory Testing Bots**: [AI-driven testing bots](/testing-bot/) that mimic user behavior and uncover hidden defects, offering insights that scripted tests might miss.
 - **Scriptless Testing Tools**: Platforms for test creation without coding, leveraging AI to build robust scenarios with minimal user input.
-- **Code-Driven AI Bots**: Solutions like Wopee.io’s [Playwright AI Bot](/blog/playwright-bot-ai-powered-test-automation) that enhance traditional frameworks by automating repetitive tasks and delivering intelligent insights.
+- **Code-Driven AI Bots**: Solutions like Wopee.io’s [Playwright AI Bot](/blog/playwright-bot-ai-powered-test-automation/) that enhance traditional frameworks by automating repetitive tasks and delivering intelligent insights.
+- **Self-Healing Agents**: Agents that regenerate broken locators — or whole flows — when the UI changes, so suites stay green without manual selector fixes. See [self-healing test automation](/blog/self-healing-in-sw-test-automation/) for how the leading approaches compare.
+- **Predictive Selection Agents**: Agents that rank tests by failure risk and run the riskiest first, cutting CI time without losing coverage — see [predictive test selection](/blog/predictive-test-selection/).
 
 ## Future Trends in AI Testing Agents
 


### PR DESCRIPTION
Content refresh + internal linking for 5 blog posts stuck on page 2 of Google (positions 10-13, low CTR). Titles/meta were already shipped in #167 — this PR is content depth + internal links only.

## Content refresh
- **self-healing-in-sw-test-automation** (highest leverage): added a "2026 update" callout near the top, and replaced the thin tools list with a side-by-side comparison table (Wopee.io vs Healenium vs Testim vs Mabl) covering locator self-healing approach, runtime, maintenance burden removed, visual testing, and hosting — plus honest caveats (locator vs visual healing, self-hosted vs SaaS, "heals the test" vs "heals the selector") and per-tool detail.
- **ai-testing-agents** (blog post): added a "What Actually Works in 2026 (and What Still Doesn't)" section with an honest works/hype split and a "start narrow" takeaway; expanded the Examples list with self-healing and predictive-selection agent types.

## Internal linking
Added contextually relevant in-body links between the 5 target posts (no link stuffing), and fixed one missing trailing slash on an existing playwright-bot link. Final inter-post link coverage:
- self-healing -> getting-started (visual), playwright-bot, predictive, /ai-testing-agents/
- ai-testing-agents -> self-healing, getting-started, predictive, playwright-bot
- playwright-bot -> self-healing, getting-started
- predictive -> self-healing, playwright-bot, /ai-testing-agents/
- getting-started -> self-healing, playwright-bot

Note: the /visual-testing/ and /ai-testing-agents/ landing pages are composed entirely of shared marketing section components with no prose body — adding a blog link there would inject it into every page using those components, so no link was forced where it didn't fit naturally.

## Verification
`yarn build` passes — MDX compiles with no errors, all 5 pages and the new comparison table render. Only output is pre-existing TOC broken-anchor warnings on unrelated posts.

Refs #222.