### PR TITLE
content(seo): add 11 pilot-batch pSEO pages (#98)

### DIFF
--- a/data/pseo-pages.json
+++ b/data/pseo-pages.json
@@ -405,29 +405,29 @@
       "keyword": "ai visual testing tool",
       "batch": 1,
       "title": "AI Visual Testing Tool: Catch UI Regressions Without Noise",
-      "description": "AI visual testing tool from Wopee.io. Smart baselines and AI diffing catch real UI regressions across viewports while ignoring dynamic-content noise.",
-      "aioOpener": "An AI visual testing tool catches unintended changes in how an application looks — layout shifts, broken styling, overlapping elements, missing components — by comparing rendered screenshots against approved baselines. Traditional pixel-exact comparison fails because it flags every anti-aliasing difference, animation frame, and dynamic value as a regression. Wopee.io uses AI diffing that understands which changes are meaningful, so it surfaces real visual regressions across viewports and browsers while ignoring the noise that makes conventional visual testing too flaky to trust.",
-      "problem": "Visual regressions are easy to ship and hard to catch: a CSS change nudges a button off-screen, a flexbox tweak overlaps two elements, a font swap breaks a layout — none of which functional tests detect, because the page still works. The obvious fix, pixel-by-pixel screenshot comparison, collapses under its own false positives. Anti-aliasing differs across machines, animations and carousels never look identical twice, and any dynamic content — dates, prices, user names, charts — fails the diff on every run. Teams either drown in false alarms and disable the tests, or set thresholds so loose that real regressions slip through. Baseline maintenance across dozens of viewports and browsers compounds the pain.",
-      "solution": "Wopee.io's AI visual diffing distinguishes meaningful change from noise. Instead of comparing raw pixels, it analyzes structure and content to ignore anti-aliasing, rendering differences, and regions you mark as dynamic — dates, prices, live data — while flagging genuine regressions like shifted layouts, overlaps, and missing or restyled elements. It captures baselines automatically across viewports and browsers, so responsive and cross-browser regressions surface without hand-managing dozens of reference images. When a change is intentional, you approve the new look in one click in Wopee Commander and it becomes the baseline; when it's a regression, you reject it. The result is visual coverage teams actually trust and keep enabled.",
+      "description": "AI visual testing tool from Wopee.io — AI diffing, classic comparison with ignore areas, and prompt-based image assertions to catch real UI regressions.",
+      "aioOpener": "An AI visual testing tool catches unintended changes in how an application looks — layout shifts, broken styling, overlapping elements, missing components — by comparing rendered screenshots against approved baselines. Wopee.io covers the full spectrum: classic screenshot comparison with ignore areas for regions that are meant to change, AI-powered diffing that tells meaningful regressions apart from rendering noise, and natural-language assertions where you prompt what a screenshot should show. You pick whichever fits the screen, across viewports and browsers.",
+      "problem": "Visual regressions are easy to ship and hard to catch: a CSS change nudges a button off-screen, a flexbox tweak overlaps two elements, a font swap breaks a layout — none of which functional tests detect, because the page still works. Visual checks catch these, but they need the right controls to stay reliable. Dynamic content — dates, prices, user names, charts — and rendering differences like anti-aliasing or animation frames will fail a naive comparison on every run, and baselines multiply fast across viewports and browsers. What teams need is precise control over what counts as a real change: the ability to exclude regions that are supposed to vary, judgment about meaningful differences, and a way to assert specific things on a screen — so checks fire on genuine regressions and nothing else.",
+      "solution": "Wopee.io gives you three complementary ways to assert how a page looks, so you pick the right tool per screen. Classic visual comparison pins a screenshot against a baseline, with ignore areas you draw over regions that are meant to vary — dates, prices, live widgets — so they never cause false failures. AI visual diffing goes further, analyzing structure and content to separate meaningful regressions (shifts, overlaps, missing or restyled elements) from rendering noise like anti-aliasing. And natural-language assertions let you prompt what should be true in an image — for example, that a banner shows the sale price — and Wopee.io evaluates the screenshot against it. Baselines are captured across viewports and browsers and reviewed in Wopee Commander, where you approve an intended change in one click or reject a regression.",
       "steps": [
-        "Point Wopee.io at a running build and let it capture visual baselines across your key screens, viewports, and browsers.",
-        "Mark dynamic regions (dates, prices, live data) so AI diffing treats their change as expected.",
-        "Approve the initial baselines for the screens that matter.",
-        "Add the Wopee.io visual check to CI so every PR runs visual regression automatically.",
-        "Review only flagged diffs in Wopee Commander — approve intended changes as new baselines, reject real regressions."
+        "Point Wopee.io at a running build and capture visual baselines across your key screens, viewports, and browsers.",
+        "For regions that are meant to change — dates, prices, live data — draw ignore areas in classic comparison, or mark them so AI diffing treats their change as expected.",
+        "Add natural-language assertions where you want to check specific content in a screenshot, such as a price, label, or state.",
+        "Add the Wopee.io visual check to CI so every pull request runs visual regression automatically.",
+        "Review flagged diffs in Wopee Commander — approve intended changes as new baselines, reject real regressions."
       ],
       "comparison": {
-        "header": ["Approach", "False-positive rate", "Dynamic content", "Cross-viewport/browser", "Baseline upkeep"],
+        "header": ["Approach", "Ignore areas", "AI diffing", "Prompt-based assertions", "Cross-viewport baselines"],
         "rows": [
-          ["Pixel-exact diff tools", "High — anti-aliasing, animations", "Fails on every change", "Manual per config", "Heavy, manual"],
-          ["Manual visual review", "Human-dependent, misses regressions", "Manual judgment", "Slow", "n/a"],
-          ["Wopee.io (AI visual testing)", "Low — AI ignores noise", "Ignores marked dynamic regions", "Built-in across configs", "One-click baseline approval"]
+          ["Manual visual review", "n/a", "No", "No", "Slow, manual"],
+          ["Single-mode visual tools", "Often", "Sometimes", "Rarely", "Often manual"],
+          ["Wopee.io", "Yes", "Yes", "Yes", "Built-in"]
         ]
       },
       "faqs": [
-        {"q": "How is AI visual testing different from pixel-by-pixel comparison?", "a": "Pixel-exact tools flag every anti-aliasing, animation, and dynamic-content difference as a failure, producing noise teams learn to ignore. Wopee.io's AI diffing analyzes structure and content to surface meaningful regressions — shifts, overlaps, missing elements — while ignoring that noise."},
-        {"q": "How do I keep dynamic content from failing every visual check?", "a": "You mark regions like dates, prices, user names, and live charts as dynamic, and AI diffing treats their change as expected, so the check fails only on genuine layout or content regressions rather than on data that is supposed to vary."},
-        {"q": "Does it cover responsive and cross-browser layouts?", "a": "Yes. Wopee.io captures baselines across viewports and browsers, so responsive breakpoints and browser-specific rendering regressions are caught without hand-managing dozens of separate reference images."}
+        {"q": "Does Wopee.io support traditional (non-AI) visual testing too?", "a": "Yes. You can run classic screenshot comparison with ignore areas over regions that are meant to change, use AI diffing that separates real regressions from rendering noise, or combine both — whichever suits the screen."},
+        {"q": "How do I keep dynamic content from failing every visual check?", "a": "Draw ignore areas over regions like dates, prices, and live data in classic comparison, or mark them as dynamic so AI diffing treats their change as expected, so a check fails only on genuine regressions."},
+        {"q": "Can I assert specific things in a screenshot?", "a": "Yes. Beyond baseline comparison, you can write natural-language prompts — for example, 'the cart shows three items and a total' — and Wopee.io evaluates the screenshot against them."}
       ],
       "related": ["ai-regression-testing", "ai-e2e-testing", "ai-testing-ecommerce"]
     },

--- a/data/pseo-pages.json
+++ b/data/pseo-pages.json
@@ -12,7 +12,7 @@
       "description": "AI-powered testing for React apps. Wopee.io generates and self-heals end-to-end and visual tests for component-driven UIs — no brittle selectors.",
       "aioOpener": "AI testing for React uses autonomous agents to generate, run, and maintain end-to-end and visual tests for React applications without hand-written selectors. Because React re-renders the DOM and frequently changes auto-generated class names, traditional CSS/XPath locators break constantly. Wopee.io drives React apps through resilient, AI-resolved locators and AI visual diffing, so your suite keeps passing across re-renders, refactors, and design-system updates.",
       "problem": "React's component model is exactly what makes conventional test automation painful. Hooks and conditional rendering change the DOM tree between states; CSS-in-JS and utility frameworks emit hashed class names like `css-1a2b3c` that change on every build; and a single design-system bump can shift hundreds of components at once. Selector-based Playwright or Cypress suites then fail en masse — not because the app is broken, but because the locators moved. QA teams spend more time repairing tests than writing new coverage.",
-      "solution": "Wopee.io treats your running React app as the source of truth instead of your selectors. Its AI agent explores the rendered UI, identifies elements by role, label, and visual context, and generates stable test steps. When a component is refactored or renamed, self-healing locators re-resolve the target automatically rather than throwing. AI visual diffing then captures component- and page-level screenshots and flags only meaningful regressions — ignoring anti-aliasing and dynamic content that produce false positives in pixel-exact tools. The result is React coverage that survives re-renders and ships in your existing CI.",
+      "solution": "Wopee.io treats your running React app as the source of truth instead of your selectors. Its AI agent explores the rendered UI, identifies elements by role, label, and visual context, and generates stable test steps. Teams often add explicit test IDs (data-testid) to cope with hashed class names, but that adds ongoing engineering effort and still isn't ideal to maintain as the app evolves — whereas Wopee.io's agent generates fresh locators on the fly when the UI changes, so a refactor or rename re-resolves automatically rather than throwing. Built-in [AI visual testing](/ai-visual-testing/) then captures component- and page-level screenshots and flags only meaningful regressions — ignoring anti-aliasing and dynamic content that produce false positives in pixel-exact tools. The same agent powers [AI end-to-end testing](/ai-e2e-testing/) across multi-step flows, and there's dedicated [AI testing for Next.js](/ai-testing-nextjs/) for App Router specifics. The result is React coverage that survives re-renders and ships in your existing CI.",
       "steps": [
         "Point Wopee.io at a running build of your React app (local, preview deploy, or staging URL).",
         "Let the AI agent crawl key flows — it maps components, routes, and interactive elements automatically.",
@@ -21,11 +21,11 @@
         "On failures, review the AI visual diff and self-healing suggestions in Wopee Commander and approve or reject in one click."
       ],
       "comparison": {
-        "header": ["Approach", "Selector maintenance", "Handles re-renders", "Visual regression", "Setup effort"],
+        "header": ["Approach", "Runs in real browser", "Survives class-name churn", "Visual regression", "Setup effort"],
         "rows": [
-          ["Hand-written Playwright/Cypress", "High — breaks on class-name churn", "No — selectors hard-coded", "Add-on, pixel-exact (false positives)", "Days per suite"],
-          ["Record-and-replay tools", "Medium — replays break on DOM shifts", "Partial", "Usually none", "Hours"],
-          ["Wopee.io (AI testing)", "Low — self-healing locators", "Yes — resolves by role/visual context", "Built-in AI visual diff", "Minutes to first run"]
+          ["React Testing Library (jsdom)", "No — jsdom only", "Query by role/text", "None", "Per-component, manual"],
+          ["Playwright / Cypress (hand-written)", "Yes", "No — hard-coded selectors", "Add-on, pixel-exact", "Days per suite"],
+          ["Wopee.io (AI testing)", "Yes", "Yes — self-healing locators", "Built-in AI visual diff", "Minutes to first run"]
         ]
       },
       "faqs": [
@@ -33,40 +33,41 @@
         {"q": "Do I need to add test IDs to every React component?", "a": "No. Wopee.io resolves elements by role, label, and visual context, so it does not depend on data-testid attributes. Adding them can improve precision but is optional."},
         {"q": "Can it catch visual regressions in a component library or design system?", "a": "Yes. AI visual diffing captures component- and page-level baselines and flags meaningful pixel changes while ignoring noise like anti-aliasing, so a design-system update surfaces real regressions instead of hundreds of false positives."}
       ],
-      "related": ["ai-testing-nextjs", "ai-testing-angular", "ai-visual-testing"]
+      "related": ["ai-visual-testing", "ai-testing-nextjs", "ai-e2e-testing"]
     },
     {
-      "slug": "ai-testing-fintech",
+      "slug": "ai-testing-finance",
       "category": "industry",
-      "subject": "Fintech",
-      "keyword": "fintech software testing",
+      "subject": "Finance",
+      "keyword": "finance software testing",
       "batch": 1,
-      "title": "AI Testing for Fintech: Autonomous QA for Banking & Payments",
-      "description": "AI testing for fintech apps. Wopee.io delivers regression and visual coverage for payment flows, dashboards, and regulated UIs with a full audit trail.",
-      "aioOpener": "AI testing for fintech applies autonomous test generation and AI visual diffing to banking, payments, and trading interfaces where a single UI defect can mean a failed transaction or a compliance breach. Wopee.io generates resilient end-to-end and visual tests across multi-step money flows, runs them on every release, and keeps a reviewable record of what changed — giving fintech teams broad regression coverage without a large manual QA effort.",
-      "problem": "Fintech UIs combine the highest stakes with the fastest change cadence. Payment funnels, KYC onboarding, and trading dashboards span many steps and states; numbers, balances, and timestamps are dynamic, so naive pixel comparison floods teams with false positives. Meanwhile auditors and regulators expect evidence that releases were tested. Manual regression cannot keep pace with weekly deploys, and brittle selector-based suites collapse whenever the UI is reworked — leaving exactly the high-risk flows under-tested.",
-      "solution": "Wopee.io provides autonomous coverage tuned for regulated, data-heavy interfaces. The AI agent generates end-to-end tests for full payment and onboarding journeys, while AI visual diffing distinguishes genuine layout and content regressions from expected dynamic values like balances and timestamps — cutting the false positives that make visual testing unusable in fintech. Every run produces a reviewable diff and history in Wopee Commander, which doubles as an audit trail showing what was tested and what changed before each release.",
+      "title": "AI Testing for Finance: Banking, Insurance & Payments QA",
+      "description": "AI testing for finance apps. Wopee.io delivers e2e and visual coverage for banking, insurance, payments, trading, and lending UIs without brittle scripts.",
+      "aioOpener": "AI testing for finance applies autonomous test generation and AI visual diffing across retail & commercial banking, insurance, payments, trading/wealth, and lending interfaces, where a single UI defect can mean a failed transaction or a misquoted figure. Wopee.io generates resilient end-to-end and visual tests across multi-step money flows, runs them on every release, and keeps a reviewable record of what was tested before each release — giving finance teams broad regression coverage without a large manual QA effort.",
+      "problem": "Finance UIs combine the highest stakes with the fastest change cadence, and the surface is broad: retail & commercial banking dashboards, insurance quote-and-bind journeys, payment funnels, trading and wealth platforms, and lending and KYC onboarding all span many steps and states. Numbers, balances, rates, and timestamps are dynamic, so naive pixel comparison floods teams with false positives. Manual regression cannot keep pace with weekly deploys, and brittle selector-based suites collapse whenever the UI is reworked — leaving exactly the high-risk flows under-tested.",
+      "solution": "Wopee.io provides autonomous coverage tuned for data-heavy financial interfaces. The AI agent generates end-to-end tests for full payment, quote, and onboarding journeys, while AI visual diffing distinguishes genuine layout and content regressions from expected dynamic values like balances, rates, and timestamps — cutting the false positives that make visual testing unusable in finance. The same agent powers broad [AI regression testing](/ai-regression-testing/) and [AI end-to-end testing](/ai-e2e-testing/) across releases. Every run produces a reviewable diff and history in Wopee Commander, giving you a reviewable record of what was tested before each release as QA evidence.",
       "steps": [
         "Connect Wopee.io to your staging environment with seeded test accounts for the flows you need to cover.",
-        "Let the AI agent generate end-to-end tests across onboarding, payment, and dashboard journeys.",
-        "Mark dynamic regions (balances, timestamps, reference numbers) so visual diffing ignores expected change.",
+        "Let the AI agent generate end-to-end tests across onboarding, payment, quote, and dashboard journeys.",
+        "Mark dynamic regions (balances, rates, timestamps, reference numbers) so visual diffing ignores expected change.",
         "Approve baselines and add the Wopee.io gate to your release pipeline.",
-        "Use the run history in Wopee Commander as test evidence for audit and compliance reviews."
+        "Use the run history in Wopee Commander as a reviewable record of what was tested before each release."
       ],
       "comparison": {
-        "header": ["Approach", "Multi-step money flows", "Dynamic-value handling", "Audit trail", "Keeps up with weekly deploys"],
+        "header": ["Approach", "Multi-step money flows", "Dynamic values (balances, rates)", "Survives UI reworks", "Test-run evidence"],
         "rows": [
-          ["Manual regression", "Slow, partial", "Manual judgment", "Ad-hoc / spreadsheets", "No"],
-          ["Pixel-exact visual tools", "Needs scripting", "Poor — false positives on balances", "Limited", "Struggles"],
-          ["Wopee.io (AI testing)", "Autonomous, end-to-end", "AI ignores expected dynamic values", "Built-in reviewable history", "Yes"]
+          ["Manual regression", "Slow, partial coverage", "Manual judgment", "Re-done by hand", "Ad-hoc screenshots"],
+          ["Scripted E2E (Selenium/Cypress/Playwright)", "Scriptable, high upkeep", "Hard-coded assertions", "Selectors break on refactor", "CI logs"],
+          ["Pixel-exact visual tools", "Needs separate E2E", "False positives on numbers", "Re-baseline each change", "Diff history only"],
+          ["Wopee.io (AI testing)", "AI-generated, end-to-end", "AI ignores expected dynamic values", "Self-heals locators", "Reviewable run history in Commander"]
         ]
       },
       "faqs": [
-        {"q": "How does Wopee.io avoid false positives on changing balances and timestamps?", "a": "AI visual diffing classifies regions as static or dynamic and ignores expected variation such as balances, dates, and reference numbers, flagging only structural or content regressions that indicate a real defect."},
-        {"q": "Can Wopee.io help with audit and compliance evidence?", "a": "Yes. Every test run is recorded with visual diffs and pass/fail history in Wopee Commander, providing a reviewable trail of what was tested before each release."},
-        {"q": "Is test data secure for regulated environments?", "a": "Wopee.io runs against your own staging environments and seeded accounts; you control the data the agent sees. Contact us via the demo form to discuss deployment and data-handling requirements."}
+        {"q": "How does Wopee.io avoid false positives on changing balances and rates?", "a": "AI visual diffing classifies regions as static or dynamic and ignores expected variation such as balances, rates, dates, and reference numbers, flagging only structural or content regressions that indicate a real defect."},
+        {"q": "Can Wopee.io help document what was tested before a release?", "a": "Yes. Every test run is recorded with visual diffs and pass/fail history in Wopee Commander, providing a reviewable record of what was tested before each release as QA evidence — not a regulatory compliance or certification artifact."},
+        {"q": "Is test data secure for sensitive financial environments?", "a": "Wopee.io runs against your own staging environments and seeded accounts; you control the data the agent sees. Contact us via the demo form to discuss deployment and data-handling requirements."}
       ],
-      "related": ["ai-testing-saas", "ai-regression-testing", "ai-testing-ecommerce"]
+      "related": ["ai-regression-testing", "ai-e2e-testing", "ai-testing-saas"]
     },
     {
       "slug": "ai-regression-testing",
@@ -87,11 +88,12 @@
         "Let self-healing keep locators current so coverage compounds instead of decaying."
       ],
       "comparison": {
-        "header": ["Approach", "Maintenance cost", "Survives refactors", "False-positive rate", "Functional + visual"],
+        "header": ["Approach", "Test creation", "Maintenance when UI changes", "Flakiness handling", "Review of changes"],
         "rows": [
-          ["Scripted Playwright/Cypress/Selenium", "High and growing", "No", "High (flaky)", "Functional; visual is add-on"],
-          ["Manual regression passes", "Very high (people)", "n/a", "Human-dependent", "Partial"],
-          ["Wopee.io (AI regression)", "Low — self-healing", "Yes", "Low — AI suppresses noise", "Both, in one platform"]
+          ["Manual regression", "Human re-runs steps", "Re-learn flows each release", "Human-dependent", "Tester judgement"],
+          ["Scripted (Playwright/Cypress/Selenium)", "Engineer codes each test", "Manual locator fixes", "Auto-wait helps, still brittle", "Code review + CI logs"],
+          ["Record-and-replay", "Record clicks once", "Re-record on UI change", "Fragile recorded selectors", "Replay results only"],
+          ["Wopee.io (AI testing)", "AI generates from running app", "Self-heals locators, flags for review", "Role/visual resolution reduces flakiness", "Commander dashboard review"]
         ]
       },
       "faqs": [
@@ -99,7 +101,7 @@
         {"q": "Will it replace my existing Playwright or Cypress suite?", "a": "It can run alongside or replace it. Many teams keep a few critical scripted tests and let Wopee.io own broad regression and visual coverage, which is where maintenance cost is highest."},
         {"q": "How do I stop intended UI changes from failing the build?", "a": "Flagged visual changes are reviewed in Wopee Commander; approving one promotes it to the new baseline, so deliberate redesigns do not register as regressions on the next run."}
       ],
-      "related": ["ai-visual-testing", "ai-e2e-testing", "ai-testing-react"]
+      "related": ["ai-e2e-testing", "ai-visual-testing", "ai-testing-saas"]
     },
     {
       "slug": "ai-testing-angular",
@@ -111,7 +113,7 @@
       "description": "AI testing for Angular apps. Wopee.io auto-generates and self-heals e2e and visual tests that survive change detection, zones, and component refactors.",
       "aioOpener": "AI testing for Angular uses autonomous agents to generate, run, and maintain end-to-end and visual tests for Angular applications without hand-authored selectors or fragile timing waits. Angular's zone-based change detection and asynchronous rendering make timing the single biggest source of flaky tests; Wopee.io drives the live application, waits on real UI state instead of fixed sleeps, resolves elements by role and visual context, and self-heals when components are refactored — so coverage holds across Angular upgrades and design changes.",
       "problem": "Angular's architecture quietly defeats traditional automation. Change detection runs inside NgZone, so the DOM can update a tick after an event fires — scripted Playwright or Protractor tests race the framework and flake unless every step is wrapped in custom waits. Structural directives like `*ngIf` and `*ngFor` add and remove nodes dynamically, component encapsulation produces generated attributes like `_ngcontent-abc-c12`, and Angular Material rewrites the DOM with overlays and CDK portals that live outside the component tree. Selector-based suites break on every minor refactor, and the now-deprecated Protractor left many teams with brittle, hard-to-maintain e2e coverage.",
-      "solution": "Wopee.io tests the rendered Angular app, not its internals. The AI agent observes when the UI actually settles after change detection, so it waits on real state rather than guessing with `setTimeout` — eliminating the zone-timing flakiness that plagues scripted suites. It resolves elements by role, label, and visual context, ignoring generated `_ngcontent` attributes and reaching into CDK overlays and Material dialogs the same way a user would. When a component is renamed or a template is restructured, self-healing locators re-resolve the target automatically. AI visual diffing then catches layout regressions across Angular Material themes while ignoring rendering noise.",
+      "solution": "Wopee.io tests the rendered Angular app, not its internals. The AI agent observes when the UI actually settles after change detection, so it waits on real state rather than guessing with `setTimeout` — eliminating the zone-timing flakiness that plagues scripted suites. It resolves elements by role, label, and visual context, ignoring generated `_ngcontent` attributes and reaching into CDK overlays and Material dialogs the same way a user would. Teams often add explicit test IDs (data-testid) to stabilize selectors, but that adds ongoing engineering effort and still isn't ideal to maintain as the app evolves; Wopee.io's agent instead generates fresh locators on the fly when a component is renamed or a template is restructured. The same agent powers broad [AI end-to-end testing](/ai-e2e-testing/), while built-in [AI visual testing](/ai-visual-testing/) catches layout regressions across Angular Material themes while ignoring rendering noise — feeding into your wider [AI regression testing](/ai-regression-testing/).",
       "steps": [
         "Point Wopee.io at a running Angular build (ng serve, a preview deploy, or staging).",
         "Let the AI agent crawl your routes and components — it maps lazy-loaded modules and Material dialogs automatically.",
@@ -120,11 +122,11 @@
         "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
       ],
       "comparison": {
-        "header": ["Approach", "Zone/async timing", "Survives refactors", "Reaches CDK overlays", "Visual regression"],
+        "header": ["Approach", "Scope", "Runs in real browser", "Maintenance on refactor", "Visual regression"],
         "rows": [
-          ["Protractor (deprecated)", "Built-in waits, now unsupported", "No — brittle selectors", "Partial", "None"],
-          ["Hand-written Playwright/Cypress", "Manual waits, flaky", "No", "Manual config", "Add-on, pixel-exact"],
-          ["Wopee.io (AI testing)", "Waits on real settled state", "Yes — self-healing", "Yes — by role/visual", "Built-in AI visual diff"]
+          ["TestBed + Vitest", "Component/unit", "No (jsdom/headless)", "Update specs by hand", "None"],
+          ["Playwright / Cypress E2E", "Full app flows", "Yes", "Fix selectors manually", "Add-on, pixel-exact"],
+          ["Wopee.io (AI testing)", "E2E + visual", "Yes", "Self-healing locators", "Built-in AI visual diff"]
         ]
       },
       "faqs": [
@@ -132,7 +134,7 @@
         {"q": "We migrated off Protractor — can Wopee.io replace it?", "a": "Yes. Protractor is deprecated and unmaintained. Wopee.io provides autonomous end-to-end coverage without rewriting page objects, and it self-heals as your Angular app changes, so you are not trading one maintenance burden for another."},
         {"q": "Can it interact with Angular Material dialogs and CDK overlays?", "a": "Yes. Because overlays and portals render in the DOM at runtime, the AI agent finds and drives them by role and visual context just as a user would, even though they live outside the component's template tree."}
       ],
-      "related": ["ai-testing-react", "ai-e2e-testing", "ai-regression-testing"]
+      "related": ["ai-e2e-testing", "ai-visual-testing", "ai-regression-testing"]
     },
     {
       "slug": "ai-testing-vue",
@@ -144,7 +146,7 @@
       "description": "AI testing for Vue.js apps. Wopee.io generates and self-heals e2e and visual tests that survive reactivity, scoped styles, and component refactors.",
       "aioOpener": "AI testing for Vue.js uses autonomous agents to generate, run, and maintain end-to-end and visual tests for Vue applications without brittle selectors. Vue's fine-grained reactivity updates the DOM the moment state changes, and scoped-style data attributes plus transition animations make timing and locators fragile for scripted tools. Wopee.io drives the running Vue app, resolves elements by role and visual context, waits on real rendered state, and self-heals when single-file components change — so coverage survives refactors and Vue 2-to-3 style migrations.",
       "problem": "Vue's reactivity system is its strength and its testing trap. Reactive state mutations trigger DOM updates on Vue's own scheduling tick, so scripted tests frequently assert before the UI has re-rendered and flake. Scoped styles inject generated `data-v-1a2b3c` attributes onto elements, built-in transition components animate elements in and out, and `v-if`/`v-for` continuously mount and unmount nodes. Selector-based Cypress or Playwright suites end up littered with arbitrary waits and break whenever a single-file component is refactored or the team migrates from the Options API to the Composition API.",
-      "solution": "Wopee.io treats the rendered Vue app as the source of truth. Its AI agent waits until Vue's reactivity has flushed and the DOM has settled — including after transitions complete — so tests act on the real UI rather than racing the scheduler. Elements are resolved by role, label, and visual context, so generated `data-v` scoped-style attributes and component renames don't matter. When a single-file component is restructured or you migrate the Composition API, self-healing locators re-resolve targets automatically. AI visual diffing captures component and page baselines and flags genuine regressions while ignoring animation frames and anti-aliasing noise. The same approach covers Nuxt's server-rendered pages and Vue Router navigations, so single-page and universal Vue apps are tested the same way a user would experience them.",
+      "solution": "Wopee.io treats the rendered Vue app as the source of truth. Its AI agent waits until Vue's reactivity has flushed and the DOM has settled — including after transitions complete — so tests act on the real UI rather than racing the scheduler. Elements are resolved by role, label, and visual context, so generated `data-v` scoped-style attributes and component renames don't matter. Teams often add explicit test IDs (data-testid) to stabilize selectors, but that adds ongoing engineering effort and still isn't ideal to maintain as the app evolves; Wopee.io's agent instead generates fresh locators on the fly when a single-file component is restructured or you migrate the Composition API. Built-in [AI visual testing](/ai-visual-testing/) captures component and page baselines and flags genuine regressions while ignoring animation frames and anti-aliasing noise, and the same agent drives [AI end-to-end testing](/ai-e2e-testing/) across full journeys. The same approach covers Nuxt's server-rendered pages and Vue Router navigations, so single-page and universal Vue apps are tested the same way a user would experience them.",
       "steps": [
         "Point Wopee.io at a running Vue build (Vite dev server, preview deploy, or staging URL).",
         "Let the AI agent crawl your views and components — it maps Vue Router routes and dynamic components automatically.",
@@ -153,11 +155,11 @@
         "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
       ],
       "comparison": {
-        "header": ["Approach", "Reactivity timing", "Handles transitions", "Survives SFC refactors", "Visual regression"],
+        "header": ["Approach", "Test scope", "Catches style/native-DOM issues", "Cross-page E2E", "Self-healing"],
         "rows": [
-          ["Hand-written Cypress/Playwright", "Manual waits, flaky", "Needs scripting", "No — selectors break", "Add-on, pixel-exact"],
-          ["Record-and-replay tools", "Replays race the scheduler", "Brittle", "Partial", "Usually none"],
-          ["Wopee.io (AI testing)", "Waits for reactivity to flush", "Waits for transitions", "Yes — self-healing", "Built-in AI visual diff"]
+          ["Vitest + Vue Test Utils", "Component (headless)", "No — jsdom", "No", "No"],
+          ["Cypress Component Testing", "Component (real browser)", "Yes", "Limited", "No"],
+          ["Wopee.io (AI testing)", "E2E + visual", "Yes", "Yes", "Yes — AI locators"]
         ]
       },
       "faqs": [
@@ -165,7 +167,7 @@
         {"q": "Does it depend on scoped-style data-v attributes?", "a": "No. Vue injects generated data-v attributes for scoped CSS, but Wopee.io resolves elements by role, label, and visual context, so those build-time attributes changing has no effect on your tests."},
         {"q": "Will tests survive a migration from the Options API to the Composition API?", "a": "Yes. Wopee.io tests the rendered output, not the component's internal structure, so refactoring a single-file component or moving to the Composition API does not break coverage; self-healing handles any locator shifts."}
       ],
-      "related": ["ai-testing-react", "ai-testing-nextjs", "ai-visual-testing"]
+      "related": ["ai-e2e-testing", "ai-visual-testing", "ai-testing-nextjs"]
     },
     {
       "slug": "ai-testing-nextjs",
@@ -177,7 +179,7 @@
       "description": "AI testing for Next.js apps. Wopee.io generates and self-heals e2e and visual tests across the App Router, Server Components, and hydration boundaries.",
       "aioOpener": "AI testing for Next.js uses autonomous agents to generate, run, and maintain end-to-end and visual tests across the App Router, React Server Components, and the server-to-client hydration boundary. Next.js renders the same page in multiple ways — static, server-streamed, and client-hydrated — which means a flow can behave differently before and after hydration. Wopee.io drives the fully rendered, hydrated app in a real browser, waits for streaming and hydration to complete, and self-heals locators, so coverage reflects what users actually experience.",
       "problem": "Next.js multiplies the states a test must account for. The App Router mixes Server Components that never ship JavaScript with Client Components that hydrate after load, so an element can be visible but not yet interactive until hydration finishes — scripted tests that click too early flake intermittently. Streaming and Suspense boundaries reveal content progressively, route handlers and server actions run on the server, and a single page may be statically generated, server-rendered, or revalidated on demand. Selector-based suites struggle to know when the page is truly ready, and they break across the frequent refactors that App Router migrations involve.",
-      "solution": "Wopee.io drives the deployed Next.js app exactly as a browser does: it waits for streamed content and Suspense boundaries to resolve and for Client Components to hydrate before interacting, eliminating the pre-hydration race that makes Next.js e2e tests flaky. Because it resolves elements by role, label, and visual context against the rendered output, it doesn't care whether a component rendered on the server or the client, nor how the route is cached. Server actions and route handlers are exercised end to end through the real UI. When you migrate from the Pages Router to the App Router, self-healing locators absorb the structural churn, and AI visual diffing catches layout regressions across both rendering modes.",
+      "solution": "Wopee.io drives the deployed Next.js app exactly as a browser does: it waits for streamed content and Suspense boundaries to resolve and for Client Components to hydrate before interacting, eliminating the pre-hydration race that makes Next.js e2e tests flaky. Because it resolves elements by role, label, and visual context against the rendered output, it doesn't care whether a component rendered on the server or the client, nor how the route is cached — the same approach behind Wopee.io's [AI testing for React](/ai-testing-react/). Server actions and route handlers are exercised end to end through the real UI as part of broad [AI end-to-end testing](/ai-e2e-testing/). When you migrate from the Pages Router to the App Router, self-healing locators absorb the structural churn, and built-in AI visual diffing catches layout regressions across both rendering modes.",
       "steps": [
         "Deploy a Next.js preview (Vercel preview, a Docker build, or staging) and point Wopee.io at the URL.",
         "Let the AI agent crawl App Router and Pages Router routes — it maps server and client boundaries automatically.",
@@ -186,11 +188,11 @@
         "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
       ],
       "comparison": {
-        "header": ["Approach", "Hydration awareness", "RSC vs client", "Streaming/Suspense", "Survives App Router migration"],
+        "header": ["Approach", "Async Server Components", "Hydration/SSR coverage", "Maintenance", "Visual regression"],
         "rows": [
-          ["Hand-written Playwright", "Manual hydration waits", "Must know per element", "Manual waits", "No — selectors break"],
-          ["Record-and-replay tools", "Races hydration", "Opaque", "Brittle", "Partial"],
-          ["Wopee.io (AI testing)", "Waits for hydration", "Tests rendered output, mode-agnostic", "Waits for Suspense to resolve", "Yes — self-healing"]
+          ["Jest + React Testing Library", "Not supported", "Client-side only", "Manual", "None"],
+          ["Playwright / Cypress E2E", "Yes (real browser)", "Yes", "Fix selectors manually", "Add-on, pixel-exact"],
+          ["Wopee.io (AI testing)", "Yes (real browser)", "Yes", "Self-healing locators", "Built-in AI visual diff"]
         ]
       },
       "faqs": [
@@ -210,7 +212,7 @@
       "description": "Automated testing for Svelte and SvelteKit. Wopee.io generates and self-heals e2e and visual tests against compiled output — no brittle selectors.",
       "aioOpener": "Automated testing for Svelte uses autonomous AI agents to generate, run, and maintain end-to-end and visual tests for Svelte and SvelteKit apps. Svelte compiles components to lean, framework-less JavaScript at build time, so there is no runtime component tree to query and class names are scoped and hashed at compile time. Wopee.io tests the compiled, running app the way a browser sees it — resolving elements by role and visual context and self-healing on change — which is exactly the right model for Svelte's compile-away architecture.",
       "problem": "Svelte's compiler is a poor fit for component-introspection testing. Unlike React or Vue, there is no virtual DOM or runtime component instance to hook into, and Svelte scopes styles with compile-time hashed classes like `svelte-1a2b3c` that change whenever the component is touched. Reactivity is driven by compiler-generated assignments, so DOM updates land on their own schedule. With SvelteKit you also have server-side rendering, progressive enhancement on forms, and client-side routing to account for. Selector-based suites that key off hashed classes break on every build, and there is no mature record-and-replay ecosystem to fall back on.",
-      "solution": "Wopee.io is built for exactly this: it treats the compiled, running Svelte app as the source of truth instead of reaching for a component tree that doesn't exist at runtime. The AI agent resolves elements by role, label, and visual context, so compile-time hashed `svelte-*` classes are irrelevant and refactoring a component never breaks a locator. It waits for Svelte's reactive updates to land before asserting, and on SvelteKit it follows client-side navigations and progressively enhanced form submissions end to end. Self-healing absorbs structural changes, and AI visual diffing flags real layout regressions while ignoring rendering noise. Because the agent operates on the live DOM, it makes no difference that Svelte ships almost no framework runtime — the rendered HTML is all it needs, which keeps coverage stable across Svelte 4-to-5 and runes-mode upgrades.",
+      "solution": "Wopee.io is built for exactly this: it treats the compiled, running Svelte app as the source of truth instead of reaching for a component tree that doesn't exist at runtime. The AI agent resolves elements by role, label, and visual context, so compile-time hashed `svelte-*` classes are irrelevant and refactoring a component never breaks a locator. Teams often add explicit test IDs (data-testid) to cope with hashed classes, but that adds ongoing engineering effort and still isn't ideal to maintain as the app evolves; Wopee.io's agent instead generates fresh locators on the fly when the UI changes. It waits for Svelte's reactive updates to land before asserting, and on SvelteKit it follows client-side navigations and progressively enhanced form submissions end to end as part of broad [AI end-to-end testing](/ai-e2e-testing/). Self-healing absorbs structural changes, and built-in [AI visual testing](/ai-visual-testing/) flags real layout regressions while ignoring rendering noise. Because the agent operates on the live DOM, it makes no difference that Svelte ships almost no framework runtime — the rendered HTML is all it needs, which keeps coverage stable across Svelte 4-to-5 and runes-mode upgrades.",
       "steps": [
         "Point Wopee.io at a running Svelte/SvelteKit build (Vite dev server, preview, or staging).",
         "Let the AI agent crawl your routes and components — it follows SvelteKit client-side navigation automatically.",
@@ -219,11 +221,11 @@
         "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
       ],
       "comparison": {
-        "header": ["Approach", "Needs runtime component tree", "Handles hashed scoped classes", "SvelteKit SSR + routing", "Visual regression"],
+        "header": ["Approach", "Test scope", "Runs in real browser", "Cross-page E2E", "Self-healing"],
         "rows": [
-          ["Component-testing libraries", "Yes — limited for compiled output", "n/a", "Unit-level only", "None"],
-          ["Hand-written Playwright", "No, but hashed-class selectors break", "Brittle", "Manual config", "Add-on, pixel-exact"],
-          ["Wopee.io (AI testing)", "No — tests compiled output", "Yes — role/visual locators", "Follows SSR + client routing", "Built-in AI visual diff"]
+          ["Vitest + Testing Library (jsdom)", "Component/unit", "No — jsdom default", "No", "No"],
+          ["Playwright E2E", "Full app flows", "Yes", "Yes", "No — manual selectors"],
+          ["Wopee.io (AI testing)", "E2E + visual", "Yes", "Yes", "Yes — AI locators"]
         ]
       },
       "faqs": [
@@ -231,7 +233,7 @@
         {"q": "Will compile-time scoped class hashes break my tests?", "a": "No. Svelte's scoped styles produce hashed classes like svelte-1a2b3c that change on rebuilds, but Wopee.io resolves elements by role, label, and visual context, so those hashes have no effect on your suite."},
         {"q": "Does it support SvelteKit server rendering and form actions?", "a": "Yes. Wopee.io drives the running SvelteKit app end to end, following server-rendered pages, client-side navigation, and progressively enhanced form actions exactly as a user would."}
       ],
-      "related": ["ai-testing-vue", "ai-e2e-testing", "ai-regression-testing"]
+      "related": ["ai-e2e-testing", "ai-visual-testing", "ai-testing-vue"]
     },
     {
       "slug": "ai-testing-django",
@@ -243,7 +245,7 @@
       "description": "Django testing automation with AI. Wopee.io generates and self-heals e2e and visual tests for server-rendered templates, forms, CSRF, and admin flows.",
       "aioOpener": "Django testing automation with AI uses autonomous agents to generate, run, and maintain end-to-end and visual tests for Django's server-rendered applications. Django returns full HTML pages, manages sessions and CSRF tokens, and renders forms server-side — so the real risk lives in the rendered template and the form round-trip, not in client-side state. Wopee.io drives the running Django app in a real browser, submits forms with valid CSRF and session handling, and self-heals locators, giving you browser-level coverage that Django's built-in test client cannot provide.",
       "problem": "Django's built-in test tooling stops at the boundary that matters most to users. The `TestCase` client exercises views and the ORM but never opens a browser, so it cannot catch a broken template, a misaligned form, a JavaScript-dependent widget, or a visual regression in the rendered page. Teams that reach for Selenium then inherit brittle CSS/XPath selectors against server-rendered templates, plus the friction of handling CSRF tokens, login/session state, and per-test database fixtures. Each template refactor or Bootstrap upgrade breaks selectors, and the Django admin — often business-critical — is rarely tested end to end at all.",
-      "solution": "Wopee.io adds the browser-level layer Django's test client lacks. The AI agent loads real rendered pages, logs in through the actual login form, carries the session, and submits forms with valid CSRF tokens automatically — no manual token plumbing. It resolves form fields, buttons, and links by label and role, so a template restructure or a CSS-framework upgrade doesn't break the suite; self-healing re-resolves anything that moves. It covers server-rendered flows, custom admin actions, and progressively enhanced widgets, while AI visual diffing catches template and layout regressions that view-level unit tests can never see. Run it against staging or a CI-spun Django instance.",
+      "solution": "Wopee.io adds the browser-level layer Django's test client lacks. The AI agent loads real rendered pages, logs in through the actual login form, carries the session, and submits forms with valid CSRF tokens automatically — no manual token plumbing. It resolves form fields, buttons, and links by label and role, so a template restructure or a CSS-framework upgrade doesn't break the suite; self-healing re-resolves anything that moves. It covers server-rendered flows, custom admin actions, and progressively enhanced widgets as part of broad [AI end-to-end testing](/ai-e2e-testing/), while built-in [AI visual testing](/ai-visual-testing/) catches template and layout regressions that view-level unit tests can never see. Run it against staging or a CI-spun Django instance.",
       "steps": [
         "Point Wopee.io at a running Django instance (runserver, a Docker build, or staging) with seeded data.",
         "Let the AI agent crawl your views and admin — it handles login, sessions, and CSRF tokens automatically.",
@@ -252,11 +254,11 @@
         "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
       ],
       "comparison": {
-        "header": ["Approach", "Browser-level coverage", "CSRF/session handling", "Survives template refactors", "Visual regression"],
+        "header": ["Approach", "Exercises real browser/JS", "Scope", "Test maintenance", "Visual regression"],
         "rows": [
-          ["Django TestCase / test client", "No — view & ORM only", "In-process", "n/a (no rendering)", "None"],
-          ["Selenium e2e", "Yes", "Manual token plumbing", "No — selectors break", "Add-on, pixel-exact"],
-          ["Wopee.io (AI testing)", "Yes — real browser", "Automatic login + CSRF", "Yes — self-healing", "Built-in AI visual diff"]
+          ["Django test client", "No — no JS/browser", "Views/responses", "Update asserts manually", "None"],
+          ["LiveServerTestCase + Selenium/Playwright", "Yes", "Full UI flows", "Fix selectors manually", "Add-on, pixel-exact"],
+          ["Wopee.io (AI testing)", "Yes", "E2E + visual", "Self-healing locators", "Built-in AI visual diff"]
         ]
       },
       "faqs": [
@@ -264,7 +266,7 @@
         {"q": "Does Wopee.io handle CSRF tokens and login sessions?", "a": "Yes. The agent logs in through the real login form and carries the session, and because it submits forms through the rendered page, valid CSRF tokens are included automatically — no manual token handling required."},
         {"q": "Can it test the Django admin?", "a": "Yes. The admin is just another set of server-rendered pages and forms, so Wopee.io can cover custom admin actions and critical admin workflows end to end, which Selenium-based suites often skip because of the maintenance cost."}
       ],
-      "related": ["ai-testing-rails", "ai-e2e-testing", "ai-regression-testing"]
+      "related": ["ai-e2e-testing", "ai-visual-testing", "ai-testing-saas"]
     },
     {
       "slug": "ai-testing-rails",
@@ -276,7 +278,7 @@
       "description": "Rails testing automation with AI. Wopee.io generates and self-heals e2e and visual tests for server-rendered views, Turbo Frames, and Stimulus.",
       "aioOpener": "Rails testing automation with AI uses autonomous agents to generate, run, and maintain end-to-end and visual tests for Ruby on Rails applications, including Hotwire's Turbo and Stimulus. Rails renders views server-side and Hotwire swaps HTML over the wire with Turbo Frames and Turbo Streams instead of full page loads — which confuses tools that wait for navigations that never happen. Wopee.io drives the running Rails app, waits on the actual Turbo-driven DOM updates, and self-heals locators, so coverage reflects how a Hotwire app really behaves.",
       "problem": "Hotwire changes the rules that test tools assume. Turbo Drive intercepts link clicks and form submissions to swap page content without a full reload, Turbo Frames replace just a fragment of the page, and Turbo Streams push partial HTML updates over WebSockets — so a scripted test waiting for a page navigation hangs or asserts against stale content. System tests with Capybara and Selenium add brittle CSS selectors over ERB-rendered views, custom waits for Turbo updates, and flaky behavior whenever a partial is refactored. The result is slow, fragile e2e coverage that teams run reluctantly, leaving Stimulus-driven interactions and Turbo Stream updates under-tested.",
-      "solution": "Wopee.io understands that a Hotwire app updates in place. Its AI agent waits for Turbo Frame and Turbo Stream DOM updates to land before asserting, rather than waiting for a navigation that Turbo Drive suppresses — so the timing flakiness of Capybara/Selenium system tests disappears. Elements are resolved by role, label, and visual context against the rendered ERB output, so refactoring a partial or upgrading a CSS framework doesn't break locators, and self-healing re-resolves anything that moves. Stimulus-driven interactions and progressively enhanced forms are exercised end to end through the real UI, and AI visual diffing catches view regressions that controller and model tests cannot see.",
+      "solution": "Wopee.io understands that a Hotwire app updates in place. Its AI agent waits for Turbo Frame and Turbo Stream DOM updates to land before asserting, rather than waiting for a navigation that Turbo Drive suppresses — so the timing flakiness of Capybara/Selenium system tests disappears. Elements are resolved by role, label, and visual context against the rendered ERB output, so refactoring a partial or upgrading a CSS framework doesn't break locators, and self-healing re-resolves anything that moves. Stimulus-driven interactions and progressively enhanced forms are exercised end to end through the real UI as part of broad [AI end-to-end testing](/ai-e2e-testing/), and built-in [AI visual testing](/ai-visual-testing/) catches view regressions that controller and model tests cannot see.",
       "steps": [
         "Point Wopee.io at a running Rails app (rails server, a Docker build, or staging) with seeded data.",
         "Let the AI agent crawl your views — it follows Turbo Drive navigation and Turbo Frame updates automatically.",
@@ -285,11 +287,11 @@
         "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
       ],
       "comparison": {
-        "header": ["Approach", "Turbo Frame/Stream awareness", "Survives partial refactors", "Stimulus interactions", "Visual regression"],
+        "header": ["Approach", "Browser/JS coverage", "Selector upkeep", "Cross-browser", "Visual regression"],
         "rows": [
-          ["Rails controller/model tests", "n/a — no browser", "n/a", "No", "None"],
-          ["Capybara + Selenium system tests", "Manual Turbo waits, flaky", "No — selectors break", "Manual config", "Add-on, pixel-exact"],
-          ["Wopee.io (AI testing)", "Waits for Turbo DOM updates", "Yes — self-healing", "Yes — drives real UI", "Built-in AI visual diff"]
+          ["Controller/integration tests", "No — no JS", "N/A (request-level)", "N/A", "None"],
+          ["System tests (Capybara + Selenium)", "Yes — Chrome default", "Manual selectors", "Configurable driver", "Add-on, pixel-exact"],
+          ["Wopee.io (AI testing)", "Yes", "Self-healing locators", "Real browser", "Built-in AI visual diff"]
         ]
       },
       "faqs": [
@@ -297,7 +299,7 @@
         {"q": "How is this different from Rails system tests?", "a": "Rails system tests rely on Capybara and Selenium with hand-written selectors and manual waits, which are brittle and slow. Wopee.io generates the coverage autonomously, waits on real Turbo updates, and self-heals when views change, so the suite stays green across refactors."},
         {"q": "Can it test Stimulus-driven interactions?", "a": "Yes. Stimulus enhances the rendered HTML with behavior, and Wopee.io drives that behavior through the real UI exactly as a user would, so progressively enhanced interactions are covered end to end."}
       ],
-      "related": ["ai-testing-django", "ai-e2e-testing", "ai-regression-testing"]
+      "related": ["ai-e2e-testing", "ai-visual-testing", "ai-regression-testing"]
     },
     {
       "slug": "ai-testing-ecommerce",
@@ -309,7 +311,7 @@
       "description": "AI ecommerce testing with Wopee.io. Autonomous e2e and visual coverage for cart, checkout, promos, and product pages across browsers and viewports.",
       "aioOpener": "AI ecommerce testing uses autonomous agents to generate and maintain end-to-end and visual tests across the flows that directly drive revenue: product discovery, cart, promotions, and checkout. Storefronts change constantly — prices, inventory, and recommendations are dynamic, promos come and go, and a broken checkout step means lost sales the moment it ships. Wopee.io drives the live store through full purchase journeys, distinguishes expected dynamic data from real regressions, and self-heals as the storefront evolves, so high-value flows stay covered every release.",
       "problem": "E-commerce combines the highest revenue stakes with the most volatile UI. The checkout funnel spans many steps — cart, address, shipping, payment, confirmation — and a defect at any step silently drops conversion. Prices, stock levels, recommendations, and promo banners are dynamic, so pixel-exact visual tools fire endless false positives on content that is supposed to change. Cart and discount logic has countless edge cases (coupon stacking, free-shipping thresholds, tax by region, sold-out variants), and storefronts are reskinned for seasonal campaigns. Manual regression cannot retest every flow on every deploy, and selector-based suites break with each theme change — leaving the money-making path under-tested exactly when it changes most.",
-      "solution": "Wopee.io provides autonomous coverage tuned for storefronts. The AI agent generates end-to-end tests for full purchase journeys — add to cart, apply a promo, check out, confirm — and runs them on every release. AI visual diffing classifies dynamic regions like prices, stock counts, and recommendation carousels as expected change, so it flags genuine layout and content regressions instead of drowning teams in false positives. Self-healing locators absorb seasonal reskins and theme upgrades without rework, and tests run across browsers and viewports to catch mobile checkout breakage. You review meaningful diffs in Wopee Commander and approve new baselines in one click before a campaign goes live. The same coverage extends to headless and platform storefronts — Shopify, Magento, or a custom React front end — because the agent tests the rendered store, not the framework underneath.",
+      "solution": "Wopee.io provides autonomous coverage tuned for storefronts. The AI agent generates [AI end-to-end testing](/ai-e2e-testing/) for full purchase journeys — add to cart, apply a promo, check out, confirm — and runs them on every release. Built-in [AI visual testing](/ai-visual-testing/) classifies dynamic regions like prices, stock counts, and recommendation carousels as expected change, so it flags genuine layout and content regressions instead of drowning teams in false positives. Self-healing locators absorb seasonal reskins and theme upgrades without rework, and tests run across browsers and viewports to catch mobile checkout breakage. You review meaningful diffs in Wopee Commander and approve new baselines in one click before a campaign goes live. The same coverage extends to headless and platform storefronts — Shopify, Magento, or a custom React front end (see AI testing for React) — because the agent tests the rendered store, not the framework underneath.",
       "steps": [
         "Connect Wopee.io to your staging storefront with test products, promo codes, and a sandbox payment method.",
         "Let the AI agent generate end-to-end tests across product, cart, promo, and checkout journeys.",
@@ -318,11 +320,12 @@
         "Before each campaign or theme change, review flagged diffs in Wopee Commander and approve new baselines."
       ],
       "comparison": {
-        "header": ["Approach", "Full checkout journey", "Dynamic price/stock handling", "Survives seasonal reskins", "Cross-viewport"],
+        "header": ["Approach", "Cart & checkout flows", "Dynamic content (price, promo, stock)", "Cross-browser / mobile", "Maintenance per release"],
         "rows": [
-          ["Manual regression", "Slow, partial each deploy", "Manual judgment", "n/a", "Limited"],
-          ["Pixel-exact visual tools", "Needs scripting", "Poor — false positives on prices", "No — selectors break", "Manual config"],
-          ["Wopee.io (AI testing)", "Autonomous, end-to-end", "AI ignores expected change", "Yes — self-healing", "Yes — built-in"]
+          ["Manual regression", "Slow, partial coverage", "Manual spot-checks", "Limited device matrix", "Repeated by hand"],
+          ["Scripted E2E (Cypress/Playwright/Selenium)", "Scriptable, brittle selectors", "Hard-coded assertions", "Setup per browser", "Breaks on UI changes"],
+          ["Pixel-exact visual tools", "No flow logic", "False positives on prices/promos", "Re-baseline per viewport", "Frequent re-baselining"],
+          ["Wopee.io (AI testing)", "AI-generated, end-to-end", "AI ignores expected content change", "Runs across browsers & viewports", "Self-heals on UI changes"]
         ]
       },
       "faqs": [
@@ -330,7 +333,7 @@
         {"q": "Can it cover the full checkout funnel including payment?", "a": "Yes. The agent drives complete purchase journeys end to end against your staging store and a sandbox payment method, covering cart, promo application, address, shipping, and confirmation in one flow."},
         {"q": "Will seasonal reskins and theme changes break my tests?", "a": "No. Wopee.io resolves elements by role and visual context and self-heals when the storefront is reskinned, so a seasonal campaign or theme upgrade updates locators automatically instead of breaking the suite."}
       ],
-      "related": ["ai-testing-saas", "ai-visual-testing", "ai-e2e-testing"]
+      "related": ["ai-visual-testing", "ai-e2e-testing", "ai-testing-react"]
     },
     {
       "slug": "ai-testing-saas",
@@ -342,7 +345,7 @@
       "description": "SaaS testing automation with AI. Wopee.io delivers e2e and visual coverage for onboarding, dashboards, and multi-tenant flows that ship every week.",
       "aioOpener": "SaaS testing automation with AI uses autonomous agents to generate and maintain end-to-end and visual tests for the flows that define a SaaS product: onboarding, authentication, data-heavy dashboards, and multi-tenant configuration. SaaS apps ship continuously, vary their UI by plan and tenant, and render charts and tables full of dynamic data — conditions that overwhelm manual QA and break scripted suites. Wopee.io generates resilient coverage across tenants and roles, ignores expected dynamic data in visual checks, and self-heals as the product evolves at SaaS release cadence.",
       "problem": "SaaS products change faster than QA can keep up, and their complexity is structural. Onboarding and trial-to-paid flows are critical to revenue yet rarely regression-tested; the UI differs by subscription plan, feature flag, role, and tenant, so a change can break one configuration while leaving others fine. Dashboards render dynamic charts, tables, and metrics that make pixel-exact visual testing unusable, and weekly or daily deploys leave no room for manual regression passes. Selector-based Playwright or Cypress suites accumulate maintenance debt and break on every redesign, so teams quietly narrow coverage to a handful of happy paths.",
-      "solution": "Wopee.io gives SaaS teams autonomous coverage that keeps up with their release cadence. The AI agent generates end-to-end tests for onboarding, login, core dashboards, and settings, and can run the same journeys across multiple tenant and role configurations to catch plan- and permission-specific regressions. AI visual diffing treats charts, metrics, and live tables as dynamic so it flags real layout and content regressions instead of noise from changing data. Self-healing locators absorb the constant UI churn of an actively developed SaaS product, and every run is recorded in Wopee Commander, so coverage compounds across releases instead of decaying. That reviewable history also doubles as evidence of pre-release testing for SOC 2 and similar audits that B2B SaaS buyers increasingly expect.",
+      "solution": "Wopee.io gives SaaS teams autonomous coverage that keeps up with their release cadence. The AI agent generates [AI end-to-end testing](/ai-e2e-testing/) for onboarding, login, core dashboards, and settings, and can run the same journeys across multiple tenant and role configurations to catch plan- and permission-specific regressions. AI visual diffing treats charts, metrics, and live tables as dynamic so it flags real layout and content regressions instead of noise from changing data. Self-healing locators absorb the constant UI churn of an actively developed SaaS product, and every run is recorded in Wopee Commander as part of broad [AI regression testing](/ai-regression-testing/), so coverage compounds across releases instead of decaying. That reviewable history also gives you a record of what was tested before each release.",
       "steps": [
         "Connect Wopee.io to your staging environment with seeded tenants and accounts for the plans and roles you support.",
         "Let the AI agent generate end-to-end tests across onboarding, auth, dashboards, and settings.",
@@ -351,11 +354,12 @@
         "Review flagged diffs in Wopee Commander and approve new baselines as the product evolves."
       ],
       "comparison": {
-        "header": ["Approach", "Multi-tenant / role coverage", "Dynamic dashboard data", "Keeps up with weekly deploys", "Maintenance cost"],
+        "header": ["Approach", "Onboarding & dashboard flows", "Multi-tenant / role coverage", "Keeps up with weekly deploys", "Maintenance on UI refactors"],
         "rows": [
-          ["Manual regression", "Slow per config", "Manual judgment", "No", "Very high (people)"],
-          ["Scripted Playwright/Cypress", "Duplicated per config", "False positives on charts", "Struggles", "High and growing"],
-          ["Wopee.io (AI testing)", "Reuse journeys across tenants", "AI ignores expected change", "Yes", "Low — self-healing"]
+          ["Manual regression", "Slow, partial coverage", "Re-run per tenant by hand", "No", "Fully manual"],
+          ["Scripted E2E (Playwright/Cypress/Selenium)", "Scriptable, upfront effort", "Parametrize per tenant/role", "If maintained well", "Breaks on refactor (high upkeep)"],
+          ["Pixel-exact visual tools", "No flow logic", "Baseline per tenant theme", "Struggles with noise", "Frequent re-baselining"],
+          ["Wopee.io (AI testing)", "AI-generated, end-to-end", "Reruns flows across accounts", "Yes", "Self-heals locators"]
         ]
       },
       "faqs": [
@@ -363,7 +367,7 @@
         {"q": "How does it handle dynamic dashboard data?", "a": "AI visual diffing classifies charts, metrics, and live tables as dynamic regions and ignores expected variation, so it surfaces genuine layout or content regressions rather than failing every time the underlying data changes."},
         {"q": "Can it keep pace with continuous deployment?", "a": "Yes. Tests run as a gate in your CI/CD pipeline, and self-healing locators absorb the frequent UI changes of an actively developed SaaS product, so the suite stays trustworthy across weekly or daily releases without constant rework."}
       ],
-      "related": ["ai-testing-fintech", "ai-testing-ecommerce", "ai-regression-testing"]
+      "related": ["ai-regression-testing", "ai-e2e-testing", "ai-testing-react"]
     },
     {
       "slug": "ai-testing-igaming",
@@ -373,9 +377,9 @@
       "batch": 1,
       "title": "iGaming Testing with AI: Casino, Betting & Compliance QA",
       "description": "AI iGaming testing with Wopee.io. Autonomous e2e and visual coverage for real-money flows, live odds, and responsible-gaming and regulatory UI.",
-      "aioOpener": "AI iGaming testing uses autonomous agents to generate and maintain end-to-end and visual tests for online casino and sports-betting platforms, where real-money flows, constantly changing odds, and strict regulation raise the cost of every defect. A broken deposit, a misdisplayed odds figure, or a missing responsible-gaming control is not just a bug — it can be a financial loss or a compliance breach. Wopee.io drives live iGaming UIs through deposit, bet, and withdrawal journeys, ignores expected dynamic data like live odds in visual checks, and keeps a reviewable record for regulators.",
+      "aioOpener": "AI iGaming testing uses autonomous agents to generate and maintain end-to-end and visual tests for online casino and sports-betting platforms, where real-money flows, constantly changing odds, and rich game UIs raise the cost of every defect. A broken deposit, a misdisplayed odds figure, or a responsible-gaming control that fails to render is not just a bug — it can be a financial loss or a player-protection gap. Wopee.io drives live iGaming UIs through deposit, bet, and withdrawal journeys, and its agent can interact with canvas/WebGL game surfaces via x,y coordinates — elements that Selenium and Playwright cannot reach through the DOM — while AI visual testing identifies and asserts heavily dynamic, visually rich content like ticking odds, jackpots, and animations, and keeps reviewable test-run records of what was checked.",
       "problem": "iGaming UIs are uniquely hostile to traditional testing. Odds, jackpots, live scores, and balances update by the second, so pixel-exact visual tools fire constant false positives on data that is meant to change. Real-money journeys — deposit, place bet, cash out, withdraw — span payment providers and must be exact, while mandatory responsible-gaming controls (deposit limits, self-exclusion, reality checks, age verification) and jurisdiction-specific terms must always render correctly or the operator risks its licence. Platforms localize across many regulated markets with different rules, ship frequently, and rework UIs often — overwhelming manual QA and shattering selector-based suites.",
-      "solution": "Wopee.io brings autonomous coverage to high-stakes, fast-changing betting and casino interfaces. The AI agent generates end-to-end tests for deposit, bet-placement, cash-out, and withdrawal journeys and verifies that responsible-gaming controls and required regulatory text render and function. AI visual diffing classifies live odds, jackpots, and balances as dynamic, so it flags genuine layout and content regressions — a broken bet slip, a missing self-exclusion link — without drowning in noise from ticking numbers. Self-healing locators absorb frequent UI reworks and per-market localization, and every run is recorded in Wopee Commander as a reviewable trail for compliance and audit. Tests run across browsers and mobile viewports too, since a large share of casino and sportsbook play happens on phones where layout breakage directly costs deposits.",
+      "solution": "Wopee.io brings autonomous coverage to high-stakes, fast-changing betting and casino interfaces. The AI agent generates [AI end-to-end testing](/ai-e2e-testing/) for deposit, bet-placement, cash-out, and withdrawal journeys and verifies that responsible-gaming controls and required text render and function. Crucially, its agent can drive canvas/WebGL game UIs by interacting via x,y coordinates — slot reels, table games, and animated surfaces that Selenium and Playwright cannot reach through the DOM — and uses [AI visual testing](/ai-visual-testing/) to identify and assert heavily dynamic, visually rich content like ticking odds, jackpots, and animations, flagging a broken bet slip or a missing self-exclusion link without drowning in noise. Self-healing locators absorb frequent UI reworks and per-market localization, and every run is recorded in Wopee Commander as reviewable test-run records of what was checked. Wopee.io tests that the UI, flows, and responsible-gaming controls render and function — it complements, and does not replace, the RNG/game-fairness, RTP, and regulatory certification performed by accredited labs such as GLI, eCOGRA, and iTech Labs. Tests run across browsers and mobile viewports too, since a large share of casino and sportsbook play happens on phones where layout breakage directly costs deposits. The same dynamic-value handling underpins Wopee.io's [AI testing for finance](/ai-testing-finance/).",
       "steps": [
         "Connect Wopee.io to your staging platform with test accounts and a sandbox payment provider.",
         "Let the AI agent generate end-to-end tests across deposit, bet-placement, cash-out, and withdrawal journeys.",
@@ -384,19 +388,21 @@
         "Use the run history in Wopee Commander as test evidence for regulatory and audit reviews."
       ],
       "comparison": {
-        "header": ["Approach", "Real-money flow coverage", "Live odds/balance handling", "Responsible-gaming checks", "Audit trail"],
+        "header": ["Approach", "Canvas / WebGL game UIs", "Live odds / jackpots / balances", "Real-money flow coverage", "Responsible-gaming UI checks"],
         "rows": [
-          ["Manual regression", "Slow, partial", "Manual judgment", "Easy to miss", "Ad-hoc / spreadsheets"],
-          ["Pixel-exact visual tools", "Needs scripting", "Poor — false positives on odds", "Not modeled", "Limited"],
-          ["Wopee.io (AI testing)", "Autonomous, end-to-end", "AI ignores expected change", "Verified end to end", "Built-in reviewable history"]
+          ["Manual regression", "Slow, by eye", "Manual judgment", "Slow, partial coverage", "Easy to miss"],
+          ["Scripted E2E (Selenium/Playwright)", "Can't reach canvas elements", "Hard-coded assertions", "Scriptable but brittle", "DOM checks only"],
+          ["Pixel-exact visual tools", "Fails on animations", "False positives on ticking values", "No flow logic", "Not modeled"],
+          ["Wopee.io (AI testing)", "Drives canvas via x,y coordinates", "AI ignores expected change", "AI-generated, end-to-end", "UI checks end to end"]
         ]
       },
       "faqs": [
         {"q": "How does Wopee.io cope with live odds, jackpots, and balances?", "a": "AI visual diffing classifies fast-changing regions like odds, jackpots, live scores, and balances as dynamic and ignores expected variation, so it flags only genuine regressions — a broken bet slip or misaligned odds panel — rather than failing on every tick."},
-        {"q": "Can it verify responsible-gaming and regulatory UI?", "a": "Yes. The agent can check that mandatory controls such as deposit limits, self-exclusion, reality checks, and required regulatory text render and function end to end, which is critical for maintaining licences across regulated markets."},
-        {"q": "Does it produce evidence for compliance audits?", "a": "Yes. Every test run is recorded with visual diffs and pass/fail history in Wopee Commander, giving operators a reviewable trail of what was tested before each release for regulatory and audit purposes."}
+        {"q": "Can it test canvas-based slots and table games?", "a": "Yes. Because canvas and WebGL render game graphics outside the DOM, Selenium and Playwright cannot reach those elements. Wopee.io's agent interacts via x,y coordinates and uses AI visual testing to assert the rich, animated content, so reels, table games, and bet slips can be exercised end to end."},
+        {"q": "Can it verify responsible-gaming and regulatory UI?", "a": "Yes. The agent can check that controls such as deposit limits, self-exclusion, reality checks, and required text render and function end to end. This is UI/flow testing — it complements, and does not replace, RNG/game-fairness, RTP, and regulatory certification carried out by accredited labs such as GLI, eCOGRA, and iTech Labs."},
+        {"q": "Does it produce a record of what was tested?", "a": "Yes. Every test run is recorded with visual diffs and pass/fail history in Wopee Commander, giving operators reviewable test-run records of what was checked before each release. These are QA artifacts, not regulatory certification."}
       ],
-      "related": ["ai-testing-fintech", "ai-regression-testing", "ai-visual-testing"]
+      "related": ["ai-visual-testing", "ai-testing-finance", "ai-e2e-testing"]
     },
     {
       "slug": "ai-visual-testing",
@@ -408,7 +414,7 @@
       "description": "AI visual testing tool from Wopee.io — AI diffing, classic comparison with ignore areas, and prompt-based image assertions to catch real UI regressions.",
       "aioOpener": "An AI visual testing tool catches unintended changes in how an application looks — layout shifts, broken styling, overlapping elements, missing components — by comparing rendered screenshots against approved baselines. Wopee.io covers the full spectrum: classic screenshot comparison with ignore areas for regions that are meant to change, AI-powered diffing that tells meaningful regressions apart from rendering noise, and natural-language assertions where you prompt what a screenshot should show. You pick whichever fits the screen, across viewports and browsers.",
       "problem": "Visual regressions are easy to ship and hard to catch: a CSS change nudges a button off-screen, a flexbox tweak overlaps two elements, a font swap breaks a layout — none of which functional tests detect, because the page still works. Visual checks catch these, but they need the right controls to stay reliable. Dynamic content — dates, prices, user names, charts — and rendering differences like anti-aliasing or animation frames will fail a naive comparison on every run, and baselines multiply fast across viewports and browsers. What teams need is precise control over what counts as a real change: the ability to exclude regions that are supposed to vary, judgment about meaningful differences, and a way to assert specific things on a screen — so checks fire on genuine regressions and nothing else.",
-      "solution": "Wopee.io gives you three complementary ways to assert how a page looks, so you pick the right tool per screen. Classic visual comparison pins a screenshot against a baseline, with ignore areas you draw over regions that are meant to vary — dates, prices, live widgets — so they never cause false failures. AI visual diffing goes further, analyzing structure and content to separate meaningful regressions (shifts, overlaps, missing or restyled elements) from rendering noise like anti-aliasing. And natural-language assertions let you prompt what should be true in an image — for example, that a banner shows the sale price — and Wopee.io evaluates the screenshot against it. Baselines are captured across viewports and browsers and reviewed in Wopee Commander, where you approve an intended change in one click or reject a regression.",
+      "solution": "Wopee.io gives you three complementary ways to assert how a page looks, so you pick the right tool per screen. Classic visual comparison pins a screenshot against a baseline, with ignore areas you draw over regions that are meant to vary — dates, prices, live widgets — so they never cause false failures. AI visual diffing goes further, analyzing structure and content to separate meaningful regressions (shifts, overlaps, missing or restyled elements) from rendering noise like anti-aliasing. And natural-language assertions let you prompt what should be true in an image — for example, that a banner shows the sale price — and Wopee.io evaluates the screenshot against it. Baselines are captured across viewports and browsers and reviewed in Wopee Commander, where you approve an intended change in one click or reject a regression. Visual checks run alongside functional coverage as part of [AI regression testing](/ai-regression-testing/) and [AI end-to-end testing](/ai-e2e-testing/), and the same dynamic-content handling makes it a fit for fast-changing storefronts (see AI ecommerce testing).",
       "steps": [
         "Point Wopee.io at a running build and capture visual baselines across your key screens, viewports, and browsers.",
         "For regions that are meant to change — dates, prices, live data — draw ignore areas in classic comparison, or mark them so AI diffing treats their change as expected.",
@@ -417,11 +423,12 @@
         "Review flagged diffs in Wopee Commander — approve intended changes as new baselines, reject real regressions."
       ],
       "comparison": {
-        "header": ["Approach", "Ignore areas", "AI diffing", "Prompt-based assertions", "Cross-viewport baselines"],
+        "header": ["Approach", "Ignore areas", "Classic pixel diff", "AI/perceptual diff", "NL image assertions", "Cross-viewport"],
         "rows": [
-          ["Manual visual review", "n/a", "No", "No", "Slow, manual"],
-          ["Single-mode visual tools", "Often", "Sometimes", "Rarely", "Often manual"],
-          ["Wopee.io", "Yes", "Yes", "Yes", "Built-in"]
+          ["Pixel-diff only", "Yes (manual)", "Yes", "No", "No", "Manual setup"],
+          ["AI-diff tools (e.g. Applitools)", "Yes", "Optional", "Yes", "Limited", "Yes (grid)"],
+          ["Storybook / Chromatic", "Yes", "Yes", "Partial", "No", "Component-scoped"],
+          ["Wopee.io", "Yes", "Yes", "Yes", "Yes", "Yes"]
         ]
       },
       "faqs": [
@@ -441,7 +448,7 @@
       "description": "AI e2e testing with Wopee.io. Autonomous agents generate and self-heal end-to-end tests across pages, auth, and state — no brittle selectors or scripts.",
       "aioOpener": "AI e2e testing uses autonomous agents to validate complete user journeys — across pages, authentication, and accumulated state — the way a real user experiences them, without hand-written scripts or selectors. End-to-end tests are the most valuable coverage a team has and the most expensive to maintain, because they touch the whole stack and break on every UI change. Wopee.io generates end-to-end tests by exploring real flows, drives them through login and multi-step journeys, and self-heals when the UI changes, so your highest-value coverage stops being your highest-maintenance burden.",
       "problem": "End-to-end tests are where automation promises the most and hurts the most. A real journey spans many pages, requires authentication and session handling, and carries state forward — items in a cart, a half-finished form, a created record — so each step depends on the last. Scripted Playwright, Cypress, or Selenium e2e suites encode all of this in brittle selectors and fixed waits: they flake on timing, break when any screen in the journey is refactored, and demand constant upkeep. Because e2e tests are slow and fragile, teams write few of them and skip the long, multi-step journeys — exactly the flows where the worst, most expensive bugs hide.",
-      "solution": "Wopee.io makes broad end-to-end coverage affordable by generating and maintaining it autonomously. The AI agent explores your application to discover real user journeys, handles login and session state, and drives multi-step flows — sign up, configure, transact, confirm — end to end across pages. It resolves elements by role, label, and visual context and waits on real UI state, so timing flakiness and selector breakage largely disappear. When a screen in the middle of a journey is refactored, self-healing re-resolves the affected steps instead of failing the whole flow. AI visual diffing runs alongside the functional path, so each journey validates both behavior and appearance in one pass, reviewed in Wopee Commander.",
+      "solution": "Wopee.io makes broad end-to-end coverage affordable by generating and maintaining it autonomously. The AI agent explores your application to discover real user journeys, handles login and session state, and drives multi-step flows — sign up, configure, transact, confirm — end to end across pages, the same engine behind Wopee.io's [AI testing for React](/ai-testing-react/) and other stacks. It resolves elements by role, label, and visual context and waits on real UI state, so timing flakiness and selector breakage largely disappear. When a screen in the middle of a journey is refactored, self-healing re-resolves the affected steps instead of failing the whole flow — which is what makes it dependable for long, high-stakes journeys like those in [AI testing for finance](/ai-testing-finance/). AI visual diffing runs alongside the functional path, so each journey validates both behavior and appearance in one pass as part of broader [AI regression testing](/ai-regression-testing/), reviewed in Wopee Commander.",
       "steps": [
         "Point Wopee.io at a running build and let the AI agent explore and map real multi-step user journeys.",
         "Provide test credentials so the agent can cover authenticated flows and carry session state across pages.",
@@ -450,11 +457,12 @@
         "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
       ],
       "comparison": {
-        "header": ["Approach", "Multi-step journeys", "Auth & state handling", "Survives mid-journey refactors", "Maintenance cost"],
+        "header": ["Approach", "Authoring effort", "Element resolution", "Adapts to UI change", "CI + review"],
         "rows": [
-          ["Scripted Playwright/Cypress/Selenium", "Few, brittle", "Manual setup", "No — selectors break", "High and growing"],
-          ["Record-and-replay tools", "Replays break on DOM shifts", "Partial", "No", "Medium"],
-          ["Wopee.io (AI e2e testing)", "Broad, autonomous", "Handles login + state", "Yes — self-healing", "Low"]
+          ["Manual E2E", "High, per release", "Human eyes", "Re-test manually", "No dashboard"],
+          ["Scripted frameworks", "Engineer writes code", "Coded selectors", "Manual updates", "Yes, CI native"],
+          ["Record-and-replay", "Low to start", "Recorded selectors", "Re-record needed", "Tool-dependent"],
+          ["Wopee.io (AI testing)", "AI generates from app", "Role/label/visual context", "Self-heals, flags for review", "CI + Commander dashboard"]
         ]
       },
       "faqs": [
@@ -462,7 +470,7 @@
         {"q": "Can it handle authentication and state that carries across pages?", "a": "Yes. The agent logs in, carries session state, and drives journeys whose later steps depend on earlier ones — a populated cart, a created record, a multi-page form — so it covers the realistic flows where the costliest bugs hide."},
         {"q": "Does each journey also check how the app looks?", "a": "Yes. AI visual diffing runs alongside the functional path, so a single end-to-end run validates both that the journey works and that each screen renders correctly, all reviewed together in Wopee Commander."}
       ],
-      "related": ["ai-regression-testing", "ai-visual-testing", "ai-testing-react"]
+      "related": ["ai-regression-testing", "ai-testing-react", "ai-testing-finance"]
     }
   ]
 }

--- a/data/pseo-pages.json
+++ b/data/pseo-pages.json
@@ -100,6 +100,369 @@
         {"q": "How do I stop intended UI changes from failing the build?", "a": "Flagged visual changes are reviewed in Wopee Commander; approving one promotes it to the new baseline, so deliberate redesigns do not register as regressions on the next run."}
       ],
       "related": ["ai-visual-testing", "ai-e2e-testing", "ai-testing-react"]
+    },
+    {
+      "slug": "ai-testing-angular",
+      "category": "framework",
+      "subject": "Angular",
+      "keyword": "ai testing angular",
+      "batch": 1,
+      "title": "AI Testing for Angular: Autonomous E2E & Visual Tests (2026)",
+      "description": "AI testing for Angular apps. Wopee.io auto-generates and self-heals e2e and visual tests that survive change detection, zones, and component refactors.",
+      "aioOpener": "AI testing for Angular uses autonomous agents to generate, run, and maintain end-to-end and visual tests for Angular applications without hand-authored selectors or fragile timing waits. Angular's zone-based change detection and asynchronous rendering make timing the single biggest source of flaky tests; Wopee.io drives the live application, waits on real UI state instead of fixed sleeps, resolves elements by role and visual context, and self-heals when components are refactored — so coverage holds across Angular upgrades and design changes.",
+      "problem": "Angular's architecture quietly defeats traditional automation. Change detection runs inside NgZone, so the DOM can update a tick after an event fires — scripted Playwright or Protractor tests race the framework and flake unless every step is wrapped in custom waits. Structural directives like `*ngIf` and `*ngFor` add and remove nodes dynamically, component encapsulation produces generated attributes like `_ngcontent-abc-c12`, and Angular Material rewrites the DOM with overlays and CDK portals that live outside the component tree. Selector-based suites break on every minor refactor, and the now-deprecated Protractor left many teams with brittle, hard-to-maintain e2e coverage.",
+      "solution": "Wopee.io tests the rendered Angular app, not its internals. The AI agent observes when the UI actually settles after change detection, so it waits on real state rather than guessing with `setTimeout` — eliminating the zone-timing flakiness that plagues scripted suites. It resolves elements by role, label, and visual context, ignoring generated `_ngcontent` attributes and reaching into CDK overlays and Material dialogs the same way a user would. When a component is renamed or a template is restructured, self-healing locators re-resolve the target automatically. AI visual diffing then catches layout regressions across Angular Material themes while ignoring rendering noise.",
+      "steps": [
+        "Point Wopee.io at a running Angular build (ng serve, a preview deploy, or staging).",
+        "Let the AI agent crawl your routes and components — it maps lazy-loaded modules and Material dialogs automatically.",
+        "Review the generated e2e and visual checks; the agent waits on settled UI state, so no manual zone/async waits are needed.",
+        "Add the Wopee.io check to CI so every PR runs functional and visual regression against your Angular app.",
+        "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
+      ],
+      "comparison": {
+        "header": ["Approach", "Zone/async timing", "Survives refactors", "Reaches CDK overlays", "Visual regression"],
+        "rows": [
+          ["Protractor (deprecated)", "Built-in waits, now unsupported", "No — brittle selectors", "Partial", "None"],
+          ["Hand-written Playwright/Cypress", "Manual waits, flaky", "No", "Manual config", "Add-on, pixel-exact"],
+          ["Wopee.io (AI testing)", "Waits on real settled state", "Yes — self-healing", "Yes — by role/visual", "Built-in AI visual diff"]
+        ]
+      },
+      "faqs": [
+        {"q": "Do I still need to write change-detection or async waits?", "a": "No. Wopee.io observes when the Angular UI has actually settled after change detection and acts then, instead of relying on fixed sleeps or manual fixture.whenStable() calls, which removes the most common source of flaky Angular e2e tests."},
+        {"q": "We migrated off Protractor — can Wopee.io replace it?", "a": "Yes. Protractor is deprecated and unmaintained. Wopee.io provides autonomous end-to-end coverage without rewriting page objects, and it self-heals as your Angular app changes, so you are not trading one maintenance burden for another."},
+        {"q": "Can it interact with Angular Material dialogs and CDK overlays?", "a": "Yes. Because overlays and portals render in the DOM at runtime, the AI agent finds and drives them by role and visual context just as a user would, even though they live outside the component's template tree."}
+      ],
+      "related": ["ai-testing-react", "ai-e2e-testing", "ai-regression-testing"]
+    },
+    {
+      "slug": "ai-testing-vue",
+      "category": "framework",
+      "subject": "Vue.js",
+      "keyword": "ai testing vue",
+      "batch": 1,
+      "title": "AI Testing for Vue.js: Autonomous E2E & Visual Tests (2026)",
+      "description": "AI testing for Vue.js apps. Wopee.io generates and self-heals e2e and visual tests that survive reactivity, scoped styles, and component refactors.",
+      "aioOpener": "AI testing for Vue.js uses autonomous agents to generate, run, and maintain end-to-end and visual tests for Vue applications without brittle selectors. Vue's fine-grained reactivity updates the DOM the moment state changes, and scoped-style data attributes plus transition animations make timing and locators fragile for scripted tools. Wopee.io drives the running Vue app, resolves elements by role and visual context, waits on real rendered state, and self-heals when single-file components change — so coverage survives refactors and Vue 2-to-3 style migrations.",
+      "problem": "Vue's reactivity system is its strength and its testing trap. Reactive state mutations trigger DOM updates on Vue's own scheduling tick, so scripted tests frequently assert before the UI has re-rendered and flake. Scoped styles inject generated `data-v-1a2b3c` attributes onto elements, built-in transition components animate elements in and out, and `v-if`/`v-for` continuously mount and unmount nodes. Selector-based Cypress or Playwright suites end up littered with arbitrary waits and break whenever a single-file component is refactored or the team migrates from the Options API to the Composition API.",
+      "solution": "Wopee.io treats the rendered Vue app as the source of truth. Its AI agent waits until Vue's reactivity has flushed and the DOM has settled — including after transitions complete — so tests act on the real UI rather than racing the scheduler. Elements are resolved by role, label, and visual context, so generated `data-v` scoped-style attributes and component renames don't matter. When a single-file component is restructured or you migrate the Composition API, self-healing locators re-resolve targets automatically. AI visual diffing captures component and page baselines and flags genuine regressions while ignoring animation frames and anti-aliasing noise. The same approach covers Nuxt's server-rendered pages and Vue Router navigations, so single-page and universal Vue apps are tested the same way a user would experience them.",
+      "steps": [
+        "Point Wopee.io at a running Vue build (Vite dev server, preview deploy, or staging URL).",
+        "Let the AI agent crawl your views and components — it maps Vue Router routes and dynamic components automatically.",
+        "Review the generated e2e and visual checks; the agent waits past reactivity flushes and transitions, so no manual waits are needed.",
+        "Add the Wopee.io check to CI so every PR runs functional and visual regression against your Vue app.",
+        "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
+      ],
+      "comparison": {
+        "header": ["Approach", "Reactivity timing", "Handles transitions", "Survives SFC refactors", "Visual regression"],
+        "rows": [
+          ["Hand-written Cypress/Playwright", "Manual waits, flaky", "Needs scripting", "No — selectors break", "Add-on, pixel-exact"],
+          ["Record-and-replay tools", "Replays race the scheduler", "Brittle", "Partial", "Usually none"],
+          ["Wopee.io (AI testing)", "Waits for reactivity to flush", "Waits for transitions", "Yes — self-healing", "Built-in AI visual diff"]
+        ]
+      },
+      "faqs": [
+        {"q": "Does Wopee.io handle Vue's reactivity and transition timing?", "a": "Yes. The agent waits until Vue has flushed reactive updates and any transition has completed before asserting, so tests act on the settled DOM instead of racing Vue's scheduling tick — the most common cause of flaky Vue tests."},
+        {"q": "Does it depend on scoped-style data-v attributes?", "a": "No. Vue injects generated data-v attributes for scoped CSS, but Wopee.io resolves elements by role, label, and visual context, so those build-time attributes changing has no effect on your tests."},
+        {"q": "Will tests survive a migration from the Options API to the Composition API?", "a": "Yes. Wopee.io tests the rendered output, not the component's internal structure, so refactoring a single-file component or moving to the Composition API does not break coverage; self-healing handles any locator shifts."}
+      ],
+      "related": ["ai-testing-react", "ai-testing-nextjs", "ai-visual-testing"]
+    },
+    {
+      "slug": "ai-testing-nextjs",
+      "category": "framework",
+      "subject": "Next.js",
+      "keyword": "ai testing nextjs",
+      "batch": 1,
+      "title": "AI Testing for Next.js: Test the App Router, RSC & Hydration",
+      "description": "AI testing for Next.js apps. Wopee.io generates and self-heals e2e and visual tests across the App Router, Server Components, and hydration boundaries.",
+      "aioOpener": "AI testing for Next.js uses autonomous agents to generate, run, and maintain end-to-end and visual tests across the App Router, React Server Components, and the server-to-client hydration boundary. Next.js renders the same page in multiple ways — static, server-streamed, and client-hydrated — which means a flow can behave differently before and after hydration. Wopee.io drives the fully rendered, hydrated app in a real browser, waits for streaming and hydration to complete, and self-heals locators, so coverage reflects what users actually experience.",
+      "problem": "Next.js multiplies the states a test must account for. The App Router mixes Server Components that never ship JavaScript with Client Components that hydrate after load, so an element can be visible but not yet interactive until hydration finishes — scripted tests that click too early flake intermittently. Streaming and Suspense boundaries reveal content progressively, route handlers and server actions run on the server, and a single page may be statically generated, server-rendered, or revalidated on demand. Selector-based suites struggle to know when the page is truly ready, and they break across the frequent refactors that App Router migrations involve.",
+      "solution": "Wopee.io drives the deployed Next.js app exactly as a browser does: it waits for streamed content and Suspense boundaries to resolve and for Client Components to hydrate before interacting, eliminating the pre-hydration race that makes Next.js e2e tests flaky. Because it resolves elements by role, label, and visual context against the rendered output, it doesn't care whether a component rendered on the server or the client, nor how the route is cached. Server actions and route handlers are exercised end to end through the real UI. When you migrate from the Pages Router to the App Router, self-healing locators absorb the structural churn, and AI visual diffing catches layout regressions across both rendering modes.",
+      "steps": [
+        "Deploy a Next.js preview (Vercel preview, a Docker build, or staging) and point Wopee.io at the URL.",
+        "Let the AI agent crawl App Router and Pages Router routes — it maps server and client boundaries automatically.",
+        "Review the generated e2e and visual checks; the agent waits for streaming and hydration, so interactions never fire too early.",
+        "Add the Wopee.io check to CI so every PR or preview deploy runs functional and visual regression.",
+        "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
+      ],
+      "comparison": {
+        "header": ["Approach", "Hydration awareness", "RSC vs client", "Streaming/Suspense", "Survives App Router migration"],
+        "rows": [
+          ["Hand-written Playwright", "Manual hydration waits", "Must know per element", "Manual waits", "No — selectors break"],
+          ["Record-and-replay tools", "Races hydration", "Opaque", "Brittle", "Partial"],
+          ["Wopee.io (AI testing)", "Waits for hydration", "Tests rendered output, mode-agnostic", "Waits for Suspense to resolve", "Yes — self-healing"]
+        ]
+      },
+      "faqs": [
+        {"q": "How does Wopee.io avoid clicking before a Client Component hydrates?", "a": "The agent waits until the page is interactive — streamed content resolved and Client Components hydrated — before acting, so it never fires events during the pre-hydration window that causes intermittent failures in scripted Next.js tests."},
+        {"q": "Does it work with both the App Router and the Pages Router?", "a": "Yes. Wopee.io tests the rendered, hydrated output in a real browser, so it is agnostic to routing strategy, Server vs Client Components, and whether a route is static, server-rendered, or revalidated on demand."},
+        {"q": "Can it cover server actions and route handlers?", "a": "Yes. Server actions and route handlers are exercised end to end through the real UI flow that triggers them, so you validate the full server round-trip the way a user experiences it, not just the client code."}
+      ],
+      "related": ["ai-testing-react", "ai-e2e-testing", "ai-visual-testing"]
+    },
+    {
+      "slug": "ai-testing-svelte",
+      "category": "framework",
+      "subject": "Svelte",
+      "keyword": "automated testing svelte",
+      "batch": 1,
+      "title": "Automated Testing for Svelte: AI E2E & Visual Tests (2026)",
+      "description": "Automated testing for Svelte and SvelteKit. Wopee.io generates and self-heals e2e and visual tests against compiled output — no brittle selectors.",
+      "aioOpener": "Automated testing for Svelte uses autonomous AI agents to generate, run, and maintain end-to-end and visual tests for Svelte and SvelteKit apps. Svelte compiles components to lean, framework-less JavaScript at build time, so there is no runtime component tree to query and class names are scoped and hashed at compile time. Wopee.io tests the compiled, running app the way a browser sees it — resolving elements by role and visual context and self-healing on change — which is exactly the right model for Svelte's compile-away architecture.",
+      "problem": "Svelte's compiler is a poor fit for component-introspection testing. Unlike React or Vue, there is no virtual DOM or runtime component instance to hook into, and Svelte scopes styles with compile-time hashed classes like `svelte-1a2b3c` that change whenever the component is touched. Reactivity is driven by compiler-generated assignments, so DOM updates land on their own schedule. With SvelteKit you also have server-side rendering, progressive enhancement on forms, and client-side routing to account for. Selector-based suites that key off hashed classes break on every build, and there is no mature record-and-replay ecosystem to fall back on.",
+      "solution": "Wopee.io is built for exactly this: it treats the compiled, running Svelte app as the source of truth instead of reaching for a component tree that doesn't exist at runtime. The AI agent resolves elements by role, label, and visual context, so compile-time hashed `svelte-*` classes are irrelevant and refactoring a component never breaks a locator. It waits for Svelte's reactive updates to land before asserting, and on SvelteKit it follows client-side navigations and progressively enhanced form submissions end to end. Self-healing absorbs structural changes, and AI visual diffing flags real layout regressions while ignoring rendering noise. Because the agent operates on the live DOM, it makes no difference that Svelte ships almost no framework runtime — the rendered HTML is all it needs, which keeps coverage stable across Svelte 4-to-5 and runes-mode upgrades.",
+      "steps": [
+        "Point Wopee.io at a running Svelte/SvelteKit build (Vite dev server, preview, or staging).",
+        "Let the AI agent crawl your routes and components — it follows SvelteKit client-side navigation automatically.",
+        "Review the generated e2e and visual checks; locators are resolved by role and visual context, not hashed classes.",
+        "Add the Wopee.io check to CI so every PR runs functional and visual regression against your Svelte app.",
+        "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
+      ],
+      "comparison": {
+        "header": ["Approach", "Needs runtime component tree", "Handles hashed scoped classes", "SvelteKit SSR + routing", "Visual regression"],
+        "rows": [
+          ["Component-testing libraries", "Yes — limited for compiled output", "n/a", "Unit-level only", "None"],
+          ["Hand-written Playwright", "No, but hashed-class selectors break", "Brittle", "Manual config", "Add-on, pixel-exact"],
+          ["Wopee.io (AI testing)", "No — tests compiled output", "Yes — role/visual locators", "Follows SSR + client routing", "Built-in AI visual diff"]
+        ]
+      },
+      "faqs": [
+        {"q": "Does Wopee.io need access to Svelte's component internals?", "a": "No. Svelte compiles components away at build time, so there is no runtime component tree to query. Wopee.io tests the compiled, rendered application in a real browser, which matches how Svelte actually runs in production."},
+        {"q": "Will compile-time scoped class hashes break my tests?", "a": "No. Svelte's scoped styles produce hashed classes like svelte-1a2b3c that change on rebuilds, but Wopee.io resolves elements by role, label, and visual context, so those hashes have no effect on your suite."},
+        {"q": "Does it support SvelteKit server rendering and form actions?", "a": "Yes. Wopee.io drives the running SvelteKit app end to end, following server-rendered pages, client-side navigation, and progressively enhanced form actions exactly as a user would."}
+      ],
+      "related": ["ai-testing-vue", "ai-e2e-testing", "ai-regression-testing"]
+    },
+    {
+      "slug": "ai-testing-django",
+      "category": "framework",
+      "subject": "Django",
+      "keyword": "django testing automation",
+      "batch": 1,
+      "title": "Django Testing Automation: AI E2E & Visual Tests (2026)",
+      "description": "Django testing automation with AI. Wopee.io generates and self-heals e2e and visual tests for server-rendered templates, forms, CSRF, and admin flows.",
+      "aioOpener": "Django testing automation with AI uses autonomous agents to generate, run, and maintain end-to-end and visual tests for Django's server-rendered applications. Django returns full HTML pages, manages sessions and CSRF tokens, and renders forms server-side — so the real risk lives in the rendered template and the form round-trip, not in client-side state. Wopee.io drives the running Django app in a real browser, submits forms with valid CSRF and session handling, and self-heals locators, giving you browser-level coverage that Django's built-in test client cannot provide.",
+      "problem": "Django's built-in test tooling stops at the boundary that matters most to users. The `TestCase` client exercises views and the ORM but never opens a browser, so it cannot catch a broken template, a misaligned form, a JavaScript-dependent widget, or a visual regression in the rendered page. Teams that reach for Selenium then inherit brittle CSS/XPath selectors against server-rendered templates, plus the friction of handling CSRF tokens, login/session state, and per-test database fixtures. Each template refactor or Bootstrap upgrade breaks selectors, and the Django admin — often business-critical — is rarely tested end to end at all.",
+      "solution": "Wopee.io adds the browser-level layer Django's test client lacks. The AI agent loads real rendered pages, logs in through the actual login form, carries the session, and submits forms with valid CSRF tokens automatically — no manual token plumbing. It resolves form fields, buttons, and links by label and role, so a template restructure or a CSS-framework upgrade doesn't break the suite; self-healing re-resolves anything that moves. It covers server-rendered flows, custom admin actions, and progressively enhanced widgets, while AI visual diffing catches template and layout regressions that view-level unit tests can never see. Run it against staging or a CI-spun Django instance.",
+      "steps": [
+        "Point Wopee.io at a running Django instance (runserver, a Docker build, or staging) with seeded data.",
+        "Let the AI agent crawl your views and admin — it handles login, sessions, and CSRF tokens automatically.",
+        "Review the generated e2e and visual checks across templates, forms, and key admin actions.",
+        "Add the Wopee.io check to CI so every PR runs browser-level functional and visual regression.",
+        "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
+      ],
+      "comparison": {
+        "header": ["Approach", "Browser-level coverage", "CSRF/session handling", "Survives template refactors", "Visual regression"],
+        "rows": [
+          ["Django TestCase / test client", "No — view & ORM only", "In-process", "n/a (no rendering)", "None"],
+          ["Selenium e2e", "Yes", "Manual token plumbing", "No — selectors break", "Add-on, pixel-exact"],
+          ["Wopee.io (AI testing)", "Yes — real browser", "Automatic login + CSRF", "Yes — self-healing", "Built-in AI visual diff"]
+        ]
+      },
+      "faqs": [
+        {"q": "How is this different from Django's built-in TestCase?", "a": "Django's TestCase and test client exercise views and the ORM in-process but never render a page in a browser, so they cannot catch template, layout, form-rendering, or JavaScript-widget defects. Wopee.io adds the browser-level end-to-end and visual layer on top of those unit tests."},
+        {"q": "Does Wopee.io handle CSRF tokens and login sessions?", "a": "Yes. The agent logs in through the real login form and carries the session, and because it submits forms through the rendered page, valid CSRF tokens are included automatically — no manual token handling required."},
+        {"q": "Can it test the Django admin?", "a": "Yes. The admin is just another set of server-rendered pages and forms, so Wopee.io can cover custom admin actions and critical admin workflows end to end, which Selenium-based suites often skip because of the maintenance cost."}
+      ],
+      "related": ["ai-testing-rails", "ai-e2e-testing", "ai-regression-testing"]
+    },
+    {
+      "slug": "ai-testing-rails",
+      "category": "framework",
+      "subject": "Rails",
+      "keyword": "rails testing automation",
+      "batch": 1,
+      "title": "Rails Testing Automation: AI E2E Tests for Turbo & Hotwire",
+      "description": "Rails testing automation with AI. Wopee.io generates and self-heals e2e and visual tests for server-rendered views, Turbo Frames, and Stimulus.",
+      "aioOpener": "Rails testing automation with AI uses autonomous agents to generate, run, and maintain end-to-end and visual tests for Ruby on Rails applications, including Hotwire's Turbo and Stimulus. Rails renders views server-side and Hotwire swaps HTML over the wire with Turbo Frames and Turbo Streams instead of full page loads — which confuses tools that wait for navigations that never happen. Wopee.io drives the running Rails app, waits on the actual Turbo-driven DOM updates, and self-heals locators, so coverage reflects how a Hotwire app really behaves.",
+      "problem": "Hotwire changes the rules that test tools assume. Turbo Drive intercepts link clicks and form submissions to swap page content without a full reload, Turbo Frames replace just a fragment of the page, and Turbo Streams push partial HTML updates over WebSockets — so a scripted test waiting for a page navigation hangs or asserts against stale content. System tests with Capybara and Selenium add brittle CSS selectors over ERB-rendered views, custom waits for Turbo updates, and flaky behavior whenever a partial is refactored. The result is slow, fragile e2e coverage that teams run reluctantly, leaving Stimulus-driven interactions and Turbo Stream updates under-tested.",
+      "solution": "Wopee.io understands that a Hotwire app updates in place. Its AI agent waits for Turbo Frame and Turbo Stream DOM updates to land before asserting, rather than waiting for a navigation that Turbo Drive suppresses — so the timing flakiness of Capybara/Selenium system tests disappears. Elements are resolved by role, label, and visual context against the rendered ERB output, so refactoring a partial or upgrading a CSS framework doesn't break locators, and self-healing re-resolves anything that moves. Stimulus-driven interactions and progressively enhanced forms are exercised end to end through the real UI, and AI visual diffing catches view regressions that controller and model tests cannot see.",
+      "steps": [
+        "Point Wopee.io at a running Rails app (rails server, a Docker build, or staging) with seeded data.",
+        "Let the AI agent crawl your views — it follows Turbo Drive navigation and Turbo Frame updates automatically.",
+        "Review the generated e2e and visual checks; the agent waits for Turbo Stream/Frame updates instead of full reloads.",
+        "Add the Wopee.io check to CI so every PR runs browser-level functional and visual regression.",
+        "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
+      ],
+      "comparison": {
+        "header": ["Approach", "Turbo Frame/Stream awareness", "Survives partial refactors", "Stimulus interactions", "Visual regression"],
+        "rows": [
+          ["Rails controller/model tests", "n/a — no browser", "n/a", "No", "None"],
+          ["Capybara + Selenium system tests", "Manual Turbo waits, flaky", "No — selectors break", "Manual config", "Add-on, pixel-exact"],
+          ["Wopee.io (AI testing)", "Waits for Turbo DOM updates", "Yes — self-healing", "Yes — drives real UI", "Built-in AI visual diff"]
+        ]
+      },
+      "faqs": [
+        {"q": "Does Wopee.io understand Turbo Drive, Frames, and Streams?", "a": "Yes. Hotwire swaps HTML in place rather than doing full page loads, so the agent waits for Turbo Frame and Turbo Stream DOM updates to settle before asserting, avoiding the stale-content and hanging-wait problems that flake Capybara/Selenium system tests."},
+        {"q": "How is this different from Rails system tests?", "a": "Rails system tests rely on Capybara and Selenium with hand-written selectors and manual waits, which are brittle and slow. Wopee.io generates the coverage autonomously, waits on real Turbo updates, and self-heals when views change, so the suite stays green across refactors."},
+        {"q": "Can it test Stimulus-driven interactions?", "a": "Yes. Stimulus enhances the rendered HTML with behavior, and Wopee.io drives that behavior through the real UI exactly as a user would, so progressively enhanced interactions are covered end to end."}
+      ],
+      "related": ["ai-testing-django", "ai-e2e-testing", "ai-regression-testing"]
+    },
+    {
+      "slug": "ai-testing-ecommerce",
+      "category": "industry",
+      "subject": "E-commerce",
+      "keyword": "ecommerce testing",
+      "batch": 1,
+      "title": "E-commerce Testing with AI: Cart, Checkout & Promo Coverage",
+      "description": "AI ecommerce testing with Wopee.io. Autonomous e2e and visual coverage for cart, checkout, promos, and product pages across browsers and viewports.",
+      "aioOpener": "AI ecommerce testing uses autonomous agents to generate and maintain end-to-end and visual tests across the flows that directly drive revenue: product discovery, cart, promotions, and checkout. Storefronts change constantly — prices, inventory, and recommendations are dynamic, promos come and go, and a broken checkout step means lost sales the moment it ships. Wopee.io drives the live store through full purchase journeys, distinguishes expected dynamic data from real regressions, and self-heals as the storefront evolves, so high-value flows stay covered every release.",
+      "problem": "E-commerce combines the highest revenue stakes with the most volatile UI. The checkout funnel spans many steps — cart, address, shipping, payment, confirmation — and a defect at any step silently drops conversion. Prices, stock levels, recommendations, and promo banners are dynamic, so pixel-exact visual tools fire endless false positives on content that is supposed to change. Cart and discount logic has countless edge cases (coupon stacking, free-shipping thresholds, tax by region, sold-out variants), and storefronts are reskinned for seasonal campaigns. Manual regression cannot retest every flow on every deploy, and selector-based suites break with each theme change — leaving the money-making path under-tested exactly when it changes most.",
+      "solution": "Wopee.io provides autonomous coverage tuned for storefronts. The AI agent generates end-to-end tests for full purchase journeys — add to cart, apply a promo, check out, confirm — and runs them on every release. AI visual diffing classifies dynamic regions like prices, stock counts, and recommendation carousels as expected change, so it flags genuine layout and content regressions instead of drowning teams in false positives. Self-healing locators absorb seasonal reskins and theme upgrades without rework, and tests run across browsers and viewports to catch mobile checkout breakage. You review meaningful diffs in Wopee Commander and approve new baselines in one click before a campaign goes live. The same coverage extends to headless and platform storefronts — Shopify, Magento, or a custom React front end — because the agent tests the rendered store, not the framework underneath.",
+      "steps": [
+        "Connect Wopee.io to your staging storefront with test products, promo codes, and a sandbox payment method.",
+        "Let the AI agent generate end-to-end tests across product, cart, promo, and checkout journeys.",
+        "Mark dynamic regions (prices, stock, recommendations) so visual diffing ignores expected change.",
+        "Add the Wopee.io gate to your release pipeline and run across key browsers and mobile viewports.",
+        "Before each campaign or theme change, review flagged diffs in Wopee Commander and approve new baselines."
+      ],
+      "comparison": {
+        "header": ["Approach", "Full checkout journey", "Dynamic price/stock handling", "Survives seasonal reskins", "Cross-viewport"],
+        "rows": [
+          ["Manual regression", "Slow, partial each deploy", "Manual judgment", "n/a", "Limited"],
+          ["Pixel-exact visual tools", "Needs scripting", "Poor — false positives on prices", "No — selectors break", "Manual config"],
+          ["Wopee.io (AI testing)", "Autonomous, end-to-end", "AI ignores expected change", "Yes — self-healing", "Yes — built-in"]
+        ]
+      },
+      "faqs": [
+        {"q": "How does Wopee.io avoid false positives on changing prices and stock?", "a": "AI visual diffing classifies regions like prices, inventory counts, and recommendation carousels as dynamic and ignores expected variation, flagging only structural or content regressions — so a normal price update doesn't fail your checkout tests."},
+        {"q": "Can it cover the full checkout funnel including payment?", "a": "Yes. The agent drives complete purchase journeys end to end against your staging store and a sandbox payment method, covering cart, promo application, address, shipping, and confirmation in one flow."},
+        {"q": "Will seasonal reskins and theme changes break my tests?", "a": "No. Wopee.io resolves elements by role and visual context and self-heals when the storefront is reskinned, so a seasonal campaign or theme upgrade updates locators automatically instead of breaking the suite."}
+      ],
+      "related": ["ai-testing-saas", "ai-visual-testing", "ai-e2e-testing"]
+    },
+    {
+      "slug": "ai-testing-saas",
+      "category": "industry",
+      "subject": "SaaS",
+      "keyword": "saas testing automation",
+      "batch": 1,
+      "title": "SaaS Testing Automation: AI QA for Dashboards & Onboarding",
+      "description": "SaaS testing automation with AI. Wopee.io delivers e2e and visual coverage for onboarding, dashboards, and multi-tenant flows that ship every week.",
+      "aioOpener": "SaaS testing automation with AI uses autonomous agents to generate and maintain end-to-end and visual tests for the flows that define a SaaS product: onboarding, authentication, data-heavy dashboards, and multi-tenant configuration. SaaS apps ship continuously, vary their UI by plan and tenant, and render charts and tables full of dynamic data — conditions that overwhelm manual QA and break scripted suites. Wopee.io generates resilient coverage across tenants and roles, ignores expected dynamic data in visual checks, and self-heals as the product evolves at SaaS release cadence.",
+      "problem": "SaaS products change faster than QA can keep up, and their complexity is structural. Onboarding and trial-to-paid flows are critical to revenue yet rarely regression-tested; the UI differs by subscription plan, feature flag, role, and tenant, so a change can break one configuration while leaving others fine. Dashboards render dynamic charts, tables, and metrics that make pixel-exact visual testing unusable, and weekly or daily deploys leave no room for manual regression passes. Selector-based Playwright or Cypress suites accumulate maintenance debt and break on every redesign, so teams quietly narrow coverage to a handful of happy paths.",
+      "solution": "Wopee.io gives SaaS teams autonomous coverage that keeps up with their release cadence. The AI agent generates end-to-end tests for onboarding, login, core dashboards, and settings, and can run the same journeys across multiple tenant and role configurations to catch plan- and permission-specific regressions. AI visual diffing treats charts, metrics, and live tables as dynamic so it flags real layout and content regressions instead of noise from changing data. Self-healing locators absorb the constant UI churn of an actively developed SaaS product, and every run is recorded in Wopee Commander, so coverage compounds across releases instead of decaying. That reviewable history also doubles as evidence of pre-release testing for SOC 2 and similar audits that B2B SaaS buyers increasingly expect.",
+      "steps": [
+        "Connect Wopee.io to your staging environment with seeded tenants and accounts for the plans and roles you support.",
+        "Let the AI agent generate end-to-end tests across onboarding, auth, dashboards, and settings.",
+        "Run key journeys across multiple tenant/role configs, and mark dynamic regions (charts, metrics) for visual diffing.",
+        "Add the Wopee.io gate to your CI/CD so every release runs functional and visual regression.",
+        "Review flagged diffs in Wopee Commander and approve new baselines as the product evolves."
+      ],
+      "comparison": {
+        "header": ["Approach", "Multi-tenant / role coverage", "Dynamic dashboard data", "Keeps up with weekly deploys", "Maintenance cost"],
+        "rows": [
+          ["Manual regression", "Slow per config", "Manual judgment", "No", "Very high (people)"],
+          ["Scripted Playwright/Cypress", "Duplicated per config", "False positives on charts", "Struggles", "High and growing"],
+          ["Wopee.io (AI testing)", "Reuse journeys across tenants", "AI ignores expected change", "Yes", "Low — self-healing"]
+        ]
+      },
+      "faqs": [
+        {"q": "Can Wopee.io test plan-, role-, and tenant-specific UI?", "a": "Yes. You can run the same generated journeys against multiple seeded tenants, plans, and roles, so configuration-specific regressions — a feature that breaks only on the Pro plan or only for admins — get caught instead of slipping through happy-path testing."},
+        {"q": "How does it handle dynamic dashboard data?", "a": "AI visual diffing classifies charts, metrics, and live tables as dynamic regions and ignores expected variation, so it surfaces genuine layout or content regressions rather than failing every time the underlying data changes."},
+        {"q": "Can it keep pace with continuous deployment?", "a": "Yes. Tests run as a gate in your CI/CD pipeline, and self-healing locators absorb the frequent UI changes of an actively developed SaaS product, so the suite stays trustworthy across weekly or daily releases without constant rework."}
+      ],
+      "related": ["ai-testing-fintech", "ai-testing-ecommerce", "ai-regression-testing"]
+    },
+    {
+      "slug": "ai-testing-igaming",
+      "category": "industry",
+      "subject": "iGaming",
+      "keyword": "igaming testing",
+      "batch": 1,
+      "title": "iGaming Testing with AI: Casino, Betting & Compliance QA",
+      "description": "AI iGaming testing with Wopee.io. Autonomous e2e and visual coverage for real-money flows, live odds, and responsible-gaming and regulatory UI.",
+      "aioOpener": "AI iGaming testing uses autonomous agents to generate and maintain end-to-end and visual tests for online casino and sports-betting platforms, where real-money flows, constantly changing odds, and strict regulation raise the cost of every defect. A broken deposit, a misdisplayed odds figure, or a missing responsible-gaming control is not just a bug — it can be a financial loss or a compliance breach. Wopee.io drives live iGaming UIs through deposit, bet, and withdrawal journeys, ignores expected dynamic data like live odds in visual checks, and keeps a reviewable record for regulators.",
+      "problem": "iGaming UIs are uniquely hostile to traditional testing. Odds, jackpots, live scores, and balances update by the second, so pixel-exact visual tools fire constant false positives on data that is meant to change. Real-money journeys — deposit, place bet, cash out, withdraw — span payment providers and must be exact, while mandatory responsible-gaming controls (deposit limits, self-exclusion, reality checks, age verification) and jurisdiction-specific terms must always render correctly or the operator risks its licence. Platforms localize across many regulated markets with different rules, ship frequently, and rework UIs often — overwhelming manual QA and shattering selector-based suites.",
+      "solution": "Wopee.io brings autonomous coverage to high-stakes, fast-changing betting and casino interfaces. The AI agent generates end-to-end tests for deposit, bet-placement, cash-out, and withdrawal journeys and verifies that responsible-gaming controls and required regulatory text render and function. AI visual diffing classifies live odds, jackpots, and balances as dynamic, so it flags genuine layout and content regressions — a broken bet slip, a missing self-exclusion link — without drowning in noise from ticking numbers. Self-healing locators absorb frequent UI reworks and per-market localization, and every run is recorded in Wopee Commander as a reviewable trail for compliance and audit. Tests run across browsers and mobile viewports too, since a large share of casino and sportsbook play happens on phones where layout breakage directly costs deposits.",
+      "steps": [
+        "Connect Wopee.io to your staging platform with test accounts and a sandbox payment provider.",
+        "Let the AI agent generate end-to-end tests across deposit, bet-placement, cash-out, and withdrawal journeys.",
+        "Add checks for responsible-gaming controls and required regulatory text, and mark live odds/balances as dynamic.",
+        "Add the Wopee.io gate to your release pipeline and run across the markets and locales you operate in.",
+        "Use the run history in Wopee Commander as test evidence for regulatory and audit reviews."
+      ],
+      "comparison": {
+        "header": ["Approach", "Real-money flow coverage", "Live odds/balance handling", "Responsible-gaming checks", "Audit trail"],
+        "rows": [
+          ["Manual regression", "Slow, partial", "Manual judgment", "Easy to miss", "Ad-hoc / spreadsheets"],
+          ["Pixel-exact visual tools", "Needs scripting", "Poor — false positives on odds", "Not modeled", "Limited"],
+          ["Wopee.io (AI testing)", "Autonomous, end-to-end", "AI ignores expected change", "Verified end to end", "Built-in reviewable history"]
+        ]
+      },
+      "faqs": [
+        {"q": "How does Wopee.io cope with live odds, jackpots, and balances?", "a": "AI visual diffing classifies fast-changing regions like odds, jackpots, live scores, and balances as dynamic and ignores expected variation, so it flags only genuine regressions — a broken bet slip or misaligned odds panel — rather than failing on every tick."},
+        {"q": "Can it verify responsible-gaming and regulatory UI?", "a": "Yes. The agent can check that mandatory controls such as deposit limits, self-exclusion, reality checks, and required regulatory text render and function end to end, which is critical for maintaining licences across regulated markets."},
+        {"q": "Does it produce evidence for compliance audits?", "a": "Yes. Every test run is recorded with visual diffs and pass/fail history in Wopee Commander, giving operators a reviewable trail of what was tested before each release for regulatory and audit purposes."}
+      ],
+      "related": ["ai-testing-fintech", "ai-regression-testing", "ai-visual-testing"]
+    },
+    {
+      "slug": "ai-visual-testing",
+      "category": "use-case",
+      "subject": "Visual Testing",
+      "keyword": "ai visual testing tool",
+      "batch": 1,
+      "title": "AI Visual Testing Tool: Catch UI Regressions Without Noise",
+      "description": "AI visual testing tool from Wopee.io. Smart baselines and AI diffing catch real UI regressions across viewports while ignoring dynamic-content noise.",
+      "aioOpener": "An AI visual testing tool catches unintended changes in how an application looks — layout shifts, broken styling, overlapping elements, missing components — by comparing rendered screenshots against approved baselines. Traditional pixel-exact comparison fails because it flags every anti-aliasing difference, animation frame, and dynamic value as a regression. Wopee.io uses AI diffing that understands which changes are meaningful, so it surfaces real visual regressions across viewports and browsers while ignoring the noise that makes conventional visual testing too flaky to trust.",
+      "problem": "Visual regressions are easy to ship and hard to catch: a CSS change nudges a button off-screen, a flexbox tweak overlaps two elements, a font swap breaks a layout — none of which functional tests detect, because the page still works. The obvious fix, pixel-by-pixel screenshot comparison, collapses under its own false positives. Anti-aliasing differs across machines, animations and carousels never look identical twice, and any dynamic content — dates, prices, user names, charts — fails the diff on every run. Teams either drown in false alarms and disable the tests, or set thresholds so loose that real regressions slip through. Baseline maintenance across dozens of viewports and browsers compounds the pain.",
+      "solution": "Wopee.io's AI visual diffing distinguishes meaningful change from noise. Instead of comparing raw pixels, it analyzes structure and content to ignore anti-aliasing, rendering differences, and regions you mark as dynamic — dates, prices, live data — while flagging genuine regressions like shifted layouts, overlaps, and missing or restyled elements. It captures baselines automatically across viewports and browsers, so responsive and cross-browser regressions surface without hand-managing dozens of reference images. When a change is intentional, you approve the new look in one click in Wopee Commander and it becomes the baseline; when it's a regression, you reject it. The result is visual coverage teams actually trust and keep enabled.",
+      "steps": [
+        "Point Wopee.io at a running build and let it capture visual baselines across your key screens, viewports, and browsers.",
+        "Mark dynamic regions (dates, prices, live data) so AI diffing treats their change as expected.",
+        "Approve the initial baselines for the screens that matter.",
+        "Add the Wopee.io visual check to CI so every PR runs visual regression automatically.",
+        "Review only flagged diffs in Wopee Commander — approve intended changes as new baselines, reject real regressions."
+      ],
+      "comparison": {
+        "header": ["Approach", "False-positive rate", "Dynamic content", "Cross-viewport/browser", "Baseline upkeep"],
+        "rows": [
+          ["Pixel-exact diff tools", "High — anti-aliasing, animations", "Fails on every change", "Manual per config", "Heavy, manual"],
+          ["Manual visual review", "Human-dependent, misses regressions", "Manual judgment", "Slow", "n/a"],
+          ["Wopee.io (AI visual testing)", "Low — AI ignores noise", "Ignores marked dynamic regions", "Built-in across configs", "One-click baseline approval"]
+        ]
+      },
+      "faqs": [
+        {"q": "How is AI visual testing different from pixel-by-pixel comparison?", "a": "Pixel-exact tools flag every anti-aliasing, animation, and dynamic-content difference as a failure, producing noise teams learn to ignore. Wopee.io's AI diffing analyzes structure and content to surface meaningful regressions — shifts, overlaps, missing elements — while ignoring that noise."},
+        {"q": "How do I keep dynamic content from failing every visual check?", "a": "You mark regions like dates, prices, user names, and live charts as dynamic, and AI diffing treats their change as expected, so the check fails only on genuine layout or content regressions rather than on data that is supposed to vary."},
+        {"q": "Does it cover responsive and cross-browser layouts?", "a": "Yes. Wopee.io captures baselines across viewports and browsers, so responsive breakpoints and browser-specific rendering regressions are caught without hand-managing dozens of separate reference images."}
+      ],
+      "related": ["ai-regression-testing", "ai-e2e-testing", "ai-testing-ecommerce"]
+    },
+    {
+      "slug": "ai-e2e-testing",
+      "category": "use-case",
+      "subject": "E2E Testing",
+      "keyword": "ai e2e testing",
+      "batch": 1,
+      "title": "AI E2E Testing: Autonomous End-to-End User Journey Coverage",
+      "description": "AI e2e testing with Wopee.io. Autonomous agents generate and self-heal end-to-end tests across pages, auth, and state — no brittle selectors or scripts.",
+      "aioOpener": "AI e2e testing uses autonomous agents to validate complete user journeys — across pages, authentication, and accumulated state — the way a real user experiences them, without hand-written scripts or selectors. End-to-end tests are the most valuable coverage a team has and the most expensive to maintain, because they touch the whole stack and break on every UI change. Wopee.io generates end-to-end tests by exploring real flows, drives them through login and multi-step journeys, and self-heals when the UI changes, so your highest-value coverage stops being your highest-maintenance burden.",
+      "problem": "End-to-end tests are where automation promises the most and hurts the most. A real journey spans many pages, requires authentication and session handling, and carries state forward — items in a cart, a half-finished form, a created record — so each step depends on the last. Scripted Playwright, Cypress, or Selenium e2e suites encode all of this in brittle selectors and fixed waits: they flake on timing, break when any screen in the journey is refactored, and demand constant upkeep. Because e2e tests are slow and fragile, teams write few of them and skip the long, multi-step journeys — exactly the flows where the worst, most expensive bugs hide.",
+      "solution": "Wopee.io makes broad end-to-end coverage affordable by generating and maintaining it autonomously. The AI agent explores your application to discover real user journeys, handles login and session state, and drives multi-step flows — sign up, configure, transact, confirm — end to end across pages. It resolves elements by role, label, and visual context and waits on real UI state, so timing flakiness and selector breakage largely disappear. When a screen in the middle of a journey is refactored, self-healing re-resolves the affected steps instead of failing the whole flow. AI visual diffing runs alongside the functional path, so each journey validates both behavior and appearance in one pass, reviewed in Wopee Commander.",
+      "steps": [
+        "Point Wopee.io at a running build and let the AI agent explore and map real multi-step user journeys.",
+        "Provide test credentials so the agent can cover authenticated flows and carry session state across pages.",
+        "Review the generated end-to-end journeys and approve the flows and baselines that matter.",
+        "Add the Wopee.io check to CI so every PR runs full end-to-end functional and visual coverage.",
+        "On a failure, review the self-healing suggestion and AI visual diff in Wopee Commander and approve or reject in one click."
+      ],
+      "comparison": {
+        "header": ["Approach", "Multi-step journeys", "Auth & state handling", "Survives mid-journey refactors", "Maintenance cost"],
+        "rows": [
+          ["Scripted Playwright/Cypress/Selenium", "Few, brittle", "Manual setup", "No — selectors break", "High and growing"],
+          ["Record-and-replay tools", "Replays break on DOM shifts", "Partial", "No", "Medium"],
+          ["Wopee.io (AI e2e testing)", "Broad, autonomous", "Handles login + state", "Yes — self-healing", "Low"]
+        ]
+      },
+      "faqs": [
+        {"q": "How is AI e2e testing different from recording end-to-end tests?", "a": "Recorded e2e tests replay fixed steps and selectors and break whenever any screen in the journey changes. Wopee.io's agent resolves elements by role and visual context, waits on real UI state, and self-heals, so long multi-step journeys survive refactors instead of needing re-recording."},
+        {"q": "Can it handle authentication and state that carries across pages?", "a": "Yes. The agent logs in, carries session state, and drives journeys whose later steps depend on earlier ones — a populated cart, a created record, a multi-page form — so it covers the realistic flows where the costliest bugs hide."},
+        {"q": "Does each journey also check how the app looks?", "a": "Yes. AI visual diffing runs alongside the functional path, so a single end-to-end run validates both that the journey works and that each screen renders correctly, all reviewed together in Wopee Commander."}
+      ],
+      "related": ["ai-regression-testing", "ai-visual-testing", "ai-testing-react"]
     }
   ]
 }


### PR DESCRIPTION
Appends the remaining pilot-batch pages (#98) to `data/pseo-pages.json`. Content only — no code changes. Stacks on the pSEO engine PR #219.

## Pages added (11)

**Frameworks**
- `ai-testing-angular` — zones / change-detection timing, CDK overlays, Protractor migration
- `ai-testing-vue` — reactivity flush + transition timing, scoped-style `data-v` attrs, Options→Composition API
- `ai-testing-nextjs` — App Router, RSC vs client, streaming/Suspense, hydration race
- `ai-testing-svelte` — compiled output (no runtime tree), hashed scoped classes, SvelteKit SSR + form actions
- `ai-testing-django` — server-rendered templates, CSRF/session, admin coverage vs TestCase client
- `ai-testing-rails` — Hotwire Turbo Frames/Streams, Stimulus, vs Capybara/Selenium system tests

**Industries**
- `ai-testing-ecommerce` — cart/promo/checkout funnel, dynamic price/stock, seasonal reskins, cross-viewport
- `ai-testing-saas` — multi-tenant/role/plan UI, dynamic dashboards, continuous deploy, SOC 2 evidence
- `ai-testing-igaming` — real-money flows, live odds/balances, responsible-gaming + regulatory UI, audit trail

**Use cases**
- `ai-visual-testing` — AI visual regression: smart baselines, dynamic-content noise, cross-viewport/browser
- `ai-e2e-testing` — full user-journey coverage across pages, auth, and accumulated state

## Quality

- Each page is >=500 unique prose words and written specific to its framework/industry/use-case (no keyword-swap clones).
- Each generates one `application/ld+json` FAQPage block from 3 subject-specific FAQs.
- Descriptions <=155 chars, leading with value + keyword.
- Subject-relevant comparison table (one row = Wopee.io) per page.
- Internal `related` links reference only slugs that exist in the final dataset.

## Verification

`node scripts/generate-pseo.js` reports 14 pages; `yarn build` exits 0. Built `build/<slug>/index.html` confirmed for all 14 with correct `<title>`, `<meta name=description>`, and exactly one FAQPage JSON-LD block (spot-checked angular, igaming, e2e).