### PR TITLE
fix(blog): remove underline on card hover

### DIFF
--- a/src/components/blog/BlogPostCard.tsx
+++ b/src/components/blog/BlogPostCard.tsx
@@ -62,7 +62,7 @@ export default function BlogPostCard({ className }: BlogPostCardProps) {
         <h3 className="text-xl font-semibold leading-tight text-gray-900 dark:text-white m-0">
           <Link
             to={permalink}
-            className="no-underline text-inherit hover:text-secondary-wopee dark:hover:text-primary-wopee transition-colors"
+            className="no-underline hover:no-underline text-inherit hover:text-secondary-wopee dark:hover:text-primary-wopee transition-colors"
           >
             {title}
           </Link>

--- a/src/components/blog/RelatedPosts.tsx
+++ b/src/components/blog/RelatedPosts.tsx
@@ -72,7 +72,7 @@ export default function RelatedPosts({
           <Link
             key={p.permalink}
             to={p.permalink}
-            className="group flex flex-col rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden no-underline hover:shadow-lg hover:-translate-y-1 hover:border-secondary-wopee/40 dark:hover:border-primary-wopee/40 transition-all"
+            className="group flex flex-col rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 overflow-hidden no-underline hover:no-underline hover:shadow-lg hover:-translate-y-1 hover:border-secondary-wopee/40 dark:hover:border-primary-wopee/40 transition-all"
           >
             <div className="h-2 bg-gradient-to-r from-secondary-wopee to-primary-wopee" />
             <div className="flex flex-col flex-1 p-5 gap-3">


### PR DESCRIPTION
The blog "Keep reading" and listing cards underlined their entire contents (title + description + date) on hover, because the card link set a static `no-underline` but not `hover:no-underline`, so the theme's `a:hover` underline took over.

Adds `hover:no-underline` to the card links in `RelatedPosts.tsx` and `BlogPostCard.tsx`. Build verified.