### PR TITLE
fix(home,cro): restore homepage signup CTA + Google-first OAuth (conversion regression)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -281,7 +281,7 @@ const config = {
             target: "_blank",
             label: "Start for free",
             position: "right",
-            className: "margin-right--md navbar-item--hide-on-home",
+            className: "margin-right--md",
             id: "navbar-button",
           },
         ],

--- a/src/components/home-page/vibe/LoginDialog.tsx
+++ b/src/components/home-page/vibe/LoginDialog.tsx
@@ -154,21 +154,22 @@ const LoginDialog = ({
 
         {/* CTA BLOCK — primary + secondary OAuth, medium gap from header */}
         <div className="flex flex-col gap-3 mt-6">
-        {/* Primary: GitHub — full-width filled, the recommended path */}
+        {/* Primary: Google — full-width filled, the recommended path for
+            our QA/test audience (mostly Google accounts). */}
         <div
           role="button"
           tabIndex={0}
-          onClick={() => handleLogin("github")}
+          onClick={() => handleLogin("google")}
           onKeyDown={(e) => {
             if (e.key === "Enter" || e.key === " ") {
               e.preventDefault();
-              handleLogin("github");
+              handleLogin("google");
             }
           }}
           className="oauth-btn-primary inline-flex items-center justify-center gap-2 h-12 rounded-md text-sm font-semibold cursor-pointer transition-colors w-full"
         >
-          <Icon size={0.95} path={mdiGithub} />
-          <span>Continue with GitHub</span>
+          <Icon size={0.95} path={mdiGoogle} />
+          <span>Continue with Google</span>
         </div>
 
         {/* "or continue with" divider */}
@@ -180,22 +181,22 @@ const LoginDialog = ({
           <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
         </div>
 
-        {/* Secondary: Google + GitLab side by side */}
+        {/* Secondary: GitHub + GitLab side by side */}
         <div className="grid grid-cols-2 gap-2">
           <div
             role="button"
             tabIndex={0}
-            onClick={() => handleLogin("google")}
+            onClick={() => handleLogin("github")}
             onKeyDown={(e) => {
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
-                handleLogin("google");
+                handleLogin("github");
               }
             }}
             className="oauth-btn inline-flex items-center justify-center gap-1.5 h-10 rounded-md text-sm font-medium cursor-pointer transition-colors"
           >
-            <Icon size={0.75} path={mdiGoogle} color="#4285F4" />
-            <span>Google</span>
+            <Icon size={0.75} path={mdiGithub} />
+            <span>GitHub</span>
           </div>
           <div
             role="button"


### PR DESCRIPTION
## Why

Visitor→signup conversion **dropped ~63% the day the May 27 CRO batch shipped**, and has stayed down for 4 straight days while traffic held steady — a clear release regression, not noise or an incomplete week.

| | Conversion | Signups / Visitors |
|---|---|---|
| **Before** 05-27 | **6.5%** | 61 / 938 |
| **After** 05-27 | **2.4%** | 5 / 206 |

Daily, the break is a clean step-change at the deploy:

```
05-25 Mon  7.55%  ┐ healthy (pre-deploy)
05-26 Tue  6.25%  ┘
05-27 Wed  1.64%  ◄── May 27 CRO batch deploys
05-28 Thu  3.51%
05-29 Fri  1.82%
05-30 Sat  3.03%
```

Ruled out: holiday effect (holiday Mon 05-25 converted fine at 7.55%), incomplete week (per-day step-change), and the `cmd.dev.wopee.io` value in `cmdBaseUrl.js` (the prod deploy rewrites it to `cmd.wopee.io` via `sed` in `deploy.yml`).

## What this reverses

Two highest-suspicion changes from the May 27 batch:

1. **Un-hide "Start for free" navbar button on the homepage** (was hidden in `b559f51`). It links to `cmd.wopee.io/login` and was a persistent, working prod signup path. After 05-27 the hero "Try it free" modal was the *only* signup entry point on `/`.
2. **Restore Google as the primary OAuth provider** in the Vibe sign-in modal (`f869fa2` had promoted "Continue with GitHub" to the full-width primary CTA and demoted Google to a small secondary button). Our QA/testing audience is mostly on Google accounts. GitHub stays as a secondary option.

The rest of the new hero/modal redesign is kept intact.

## Follow-ups (not in this PR)
- Worth a manual check that **GitHub OAuth doesn't dead-end** on `cmd.wopee.io/signup-embedded` — if it does, that compounded the drop.
- Re-measure daily conversion 2–3 days after this deploys; expect a return toward ~6%.