### PR TITLE
Clarify homepage demo testing prompts

### DIFF
--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -23,25 +23,25 @@ const appTemplates = {
     label: "Website",
     icon: Globe,
     url: "https://dronjo.wopee.io",
-    instructions: `Goal: sign in works.
+    instructions: `Test sign in.
 Click "Sign in", use any @tesena.com email and any password.
-Pass: home page loads and a "Logout" button is visible top-right.`,
+Verify that home page loads and a "Logout" button is visible top-right.`,
   },
   [AppType.E_COMMERCE]: {
     label: "E-commerce",
     icon: ShoppingCart,
     url: "https://www.saucedemo.com",
-    instructions: `Goal: checkout works.
+    instructions: `Test check out.
 Sign in (standard_user / secret_sauce), add an item, complete checkout.
-Pass: "Thank you for your order!" appears.`,
+Verify that "Thank you for your order!" appears.`,
   },
   [AppType.BANKING]: {
     label: "Banking",
     icon: Landmark,
     url: "https://moja.tatrabanka.sk/html-tb/en/demo",
-    instructions: `Goal: PIN sign-in works.
+    instructions: `Test sign in.
 Accept the cookie banner if shown, then submit the pre-filled PIN form.
-Pass: the demo dashboard loads after submit.`,
+Verify that the dashboard loads after submit.`,
   },
   [AppType.YOUR_APPLICATION]: {
     label: "Your app",


### PR DESCRIPTION
Rewrites the three hero demo prompts into a consistent **Test → action → Verify** format (replacing the `Goal:`/`Pass:` phrasing).

- **Website:** Test sign in → sign in with any @tesena.com email → verify home page + Logout button
- **E-commerce:** Test checkout works → sign in, add item, checkout → verify "Thank you for your order!"
- **Banking:** Test sign in → accept cookies, submit pre-filled PIN → verify dashboard loads