### PR TITLE
feat(home): reveal-on-scroll navbar + drop "About us" from nav

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -253,7 +253,6 @@ const config = {
             to: "/ai-testing-agents",
             label: "Solutions",
             position: "left",
-            className: "navbar-item--hide-on-home",
             items: [
               { to: "/ai-testing-agents", label: "AI Agents for Software Testing" },
               { to: "/ai-testing", label: "AI Testing" },
@@ -265,9 +264,8 @@ const config = {
               },
             ],
           },
-          { to: "/pricing", label: "Pricing", position: "left", className: "navbar-item--hide-on-home" },
-          { to: "/blog", label: "Blog", position: "left", className: "navbar-item--hide-on-home" },
-          { to: "/about-us", label: "About us", position: "left", className: "navbar-item--hide-on-home" },
+          { to: "/pricing", label: "Pricing", position: "left" },
+          { to: "/blog", label: "Blog", position: "left" },
           {
             to: "https://cmd.wopee.io/login",
             target: "_blank",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -264,17 +264,18 @@ a.navbar__item:hover {
   filter: invert(1);
 }
 
-/* Homepage: hide primary nav links (Solutions / Pricing / Blog / About us). */
-/* They remain available in the footer and on all subpages. */
-body.is-home .navbar-item--hide-on-home,
-body.is-home .navbar-sidebar .navbar-item--hide-on-home {
-  display: none !important;
+/* Homepage: navbar hidden at top, slides in on scroll (toggled in index.tsx). */
+body.is-home .navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease;
+  will-change: transform;
 }
-/* Docusaurus strips `className` on dropdown navbar items, so hide the left-side
-   dropdown explicitly. There is no dropdown on the right (Sign In / Start for free). */
-body.is-home .theme-layout-navbar-left .navbar__item.dropdown,
-body.is-home .navbar-sidebar .menu__list-item .menu__list-item-collapsible {
-  display: none !important;
+body.is-home .navbar.navbar--revealed {
+  transform: translateY(0);
 }
 
 /* Hero primary CTA — slow pulsing glow when enabled, invites the click

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
@@ -60,6 +60,20 @@ const JSONLD_APP = {
 };
 
 export default function Home(): JSX.Element {
+  // Homepage navbar reveals on scroll; styles in custom.css.
+  useEffect(() => {
+    const navbar = document.querySelector(".navbar");
+    if (!navbar) return;
+    const sync = () =>
+      navbar.classList.toggle("navbar--revealed", window.scrollY > 8);
+    sync();
+    window.addEventListener("scroll", sync, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", sync);
+      navbar.classList.remove("navbar--revealed");
+    };
+  }, []);
+
   return (
     <Layout
       title="AI Testing Agents for Web Apps"


### PR DESCRIPTION
## What & why

The primary nav links had been hidden on the homepage (the May 27 "trim navbar on `/`" change). This brings the top menu back and gives it a reveal-on-scroll behavior on the homepage: the bar is hidden at the very top and slides in once you scroll a few pixels. Also removes **About us** from the navbar.

## Changes

- **Restore the top menu on `/`** — drop the `navbar-item--hide-on-home` classes that fully hid Solutions / Pricing / Blog. They now render on every page.
- **Reveal-on-scroll navbar (homepage only)** — the homepage navbar is `position: fixed` and parked off-screen (`translateY(-100%)`), so the hero sits flush against the top with no gap. A scroll listener in `index.tsx` toggles a `navbar--revealed` class past ~8px of scroll to slide it down (and removes it again at the top). Scoped via the existing `is-home` body class; subpages keep the default sticky navbar.
- **Remove "About us" from the navbar** site-wide. It remains linked in the footer's Company column.

## Files

- `docusaurus.config.js` — remove `hide-on-home` classes + the `/about-us` navbar item
- `src/css/custom.css` — replace the old hide rules with the fixed + slide reveal rules
- `src/pages/index.tsx` — re-add the `is-home` body class and the scroll listener

## Testing (local)

Verified on `localhost:3000`:

- Homepage **at top**: navbar hidden, hero flush to top edge.
- Homepage **scrolled**: navbar slides in (Solutions ▾ · Pricing · Blog · Sign In · Start for free); hides again at the top.
- **Subpages** (`/pricing`): normal sticky navbar, always visible.
- **Client-side nav** home → subpage leaves the navbar visible (not stuck hidden); listener cleaned up on unmount.
- "About us" gone from navbar on all pages; still present in the footer.
- `tsc` adds **0 new errors** vs `main` (pre-existing `@types/react` JSX-version noise only).

## Notes

- Reveal threshold is 8px ("a few pixels") and the slide transition is 0.3s — easy to tune.
- On mobile, the hamburger lives in the navbar, so at the very top of the homepage it's hidden too and appears once you scroll. Can keep it always-visible on mobile if preferred.