### PR TITLE
chore(home): trim hero text — drop trusted-by label + in-form trust row

### DIFF
--- a/src/components/home-page/HeroTrustedByStrip.tsx
+++ b/src/components/home-page/HeroTrustedByStrip.tsx
@@ -33,9 +33,6 @@ const HeroTrustedByStrip = () => {
   const items = [...customers, ...customers];
   return (
     <div className="relative z-10 w-full max-w-6xl px-4">
-      <p className="text-[10px] sm:text-xs tracking-[0.2em] uppercase text-gray-500 dark:text-gray-400 font-medium mb-3 text-center">
-        Trusted by leading engineering teams
-      </p>
       <div className="relative overflow-hidden mask-fade-x">
         <div className="flex items-center gap-6 sm:gap-8 animate-marquee whitespace-nowrap py-1">
           {items.map((customer, i) => (

--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -10,7 +10,6 @@ import {
   Sparkles,
   ChevronDown,
   Check,
-  CheckCircle2,
 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -375,21 +374,6 @@ const HomeHeroVibe = () => {
                   Generate my first test
                 </span>
               </Button>
-            </div>
-
-            <div className="flex flex-wrap items-center justify-center sm:justify-between gap-x-4 gap-y-1.5 text-sm text-gray-600 dark:text-gray-300">
-              <span className="inline-flex items-center gap-1.5">
-                <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0" />
-                Free to start
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0" />
-                No credit card required
-              </span>
-              <span className="inline-flex items-center gap-1.5">
-                <CheckCircle2 className="w-4 h-4 text-green-500 flex-shrink-0" />
-                Works with your Playwright setup
-              </span>
             </div>
 
           </div>


### PR DESCRIPTION
Removes two redundant text bits from the homepage hero. Two commits:

1. **`remove "Trusted by leading engineering teams" label`** — drop the heading above the customer-logo marquee (the logo marquee itself stays).
2. **`remove the in-form green trust row`** — drop "Free to start / No credit card required / Works with your Playwright setup" from inside the form (and the now-unused `CheckCircle2` import).

## Files
- `src/components/home-page/HeroTrustedByStrip.tsx` (commit 1)
- `src/components/home-page/HomeHeroVibe.tsx` (commit 2)

## Testing (local)
- Verified on `localhost:3000`: the trusted-by heading is gone (logos still animate); the form's green trust row is gone (`greenChecksInForm: 0`); the CTA is intact. `tsc` 0 new errors (185 == 185).

_Note: "No credit card required" still appears elsewhere on the page — that's the separate "How it works" CTA, untouched._