### PR TITLE
fix(home): always-visible homepage navbar (remove #229 reveal-on-scroll)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -264,20 +264,6 @@ a.navbar__item:hover {
   filter: invert(1);
 }
 
-/* Homepage: navbar hidden at top, slides in on scroll (toggled in index.tsx). */
-body.is-home .navbar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  transform: translateY(-100%);
-  transition: transform 0.3s ease;
-  will-change: transform;
-}
-body.is-home .navbar.navbar--revealed {
-  transform: translateY(0);
-}
-
 /* Hero primary CTA — slow pulsing glow when enabled, invites the click
    without ever animating loud enough to feel pushy. Disabled state stays
    still. Pulse colour matches the button fill in each theme. */

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
@@ -60,20 +60,6 @@ const JSONLD_APP = {
 };
 
 export default function Home(): JSX.Element {
-  // Homepage navbar reveals on scroll; styles in custom.css.
-  useEffect(() => {
-    const navbar = document.querySelector(".navbar");
-    if (!navbar) return;
-    const sync = () =>
-      navbar.classList.toggle("navbar--revealed", window.scrollY > 8);
-    sync();
-    window.addEventListener("scroll", sync, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", sync);
-      navbar.classList.remove("navbar--revealed");
-    };
-  }, []);
-
   return (
     <Layout
       title="AI Testing Agents for Web Apps"


### PR DESCRIPTION
Follow-up to the #230 revert (#232).

**Problem:** #232 correctly reverted the #230 hero redesign, but the navbar behaviour was never part of #230 — it came from #229. With #230 gone, #229's reveal-on-scroll navbar is orphaned: the homepage menu stays hidden at the top (`position: fixed; translateY(-100%)`) and only slides in after 8px of scroll. On the restored normal-height hero that looks like a missing menu.

**Fix:** remove only the hiding behaviour —
- `src/pages/index.tsx`: drop the scroll listener `useEffect` (and the now-unused `useEffect` import).
- `src/css/custom.css`: drop the `body.is-home .navbar` fixed/translate rules + `.navbar--revealed`.

Homepage navbar is now always visible, same as every subpage. The rest of #229 is kept intact: Solutions/Pricing/Blog still render on the homepage, and 'About us' remains footer-only.