### PR TITLE
feat(header): reveal-on-scroll navbar + minimal homepage nav

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -248,28 +248,11 @@ const config = {
           className: "margin-left--md",
         },
         items: [
-          {
-            type: "dropdown",
-            to: "/ai-testing-agents",
-            label: "Solutions",
-            position: "left",
-            items: [
-              { to: "/ai-testing-agents", label: "AI Agents for Software Testing" },
-              { to: "/ai-testing", label: "AI Testing" },
-              { to: "/visual-testing", label: "Visual Regression Testing" },
-              { to: "/mcp", label: "MCP Server" },
-              {
-                to: "blog/playwright-bot-ai-powered-test-automation",
-                label: "Playwright AI Bot (preview)",
-              },
-            ],
-          },
           { to: "/pricing", label: "Pricing", position: "left" },
-          { to: "/blog", label: "Blog", position: "left" },
           {
             to: "https://cmd.wopee.io/login",
             target: "_blank",
-            label: "Sign In",
+            label: "Log in",
             position: "right",
             className: "margin-right--md",
             id: "login-button",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -264,6 +264,20 @@ a.navbar__item:hover {
   filter: invert(1);
 }
 
+/* Homepage: navbar hidden at top, slides in on scroll (toggled in index.tsx). */
+body.is-home .navbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  transform: translateY(-100%);
+  transition: transform 0.3s ease;
+  will-change: transform;
+}
+body.is-home .navbar.navbar--revealed {
+  transform: translateY(0);
+}
+
 /* Hero primary CTA — slow pulsing glow when enabled, invites the click
    without ever animating loud enough to feel pushy. Disabled state stays
    still. Pulse colour matches the button fill in each theme. */

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
@@ -60,6 +60,20 @@ const JSONLD_APP = {
 };
 
 export default function Home(): JSX.Element {
+  // Homepage navbar reveals on scroll; styles in custom.css.
+  useEffect(() => {
+    const navbar = document.querySelector(".navbar");
+    if (!navbar) return;
+    const sync = () =>
+      navbar.classList.toggle("navbar--revealed", window.scrollY > 8);
+    sync();
+    window.addEventListener("scroll", sync, { passive: true });
+    return () => {
+      window.removeEventListener("scroll", sync);
+      navbar.classList.remove("navbar--revealed");
+    };
+  }, []);
+
   return (
     <Layout
       title="AI Testing Agents for Web Apps"


### PR DESCRIPTION
## What

Three changes to the homepage navbar:

1. **Rename "Sign In" → "Log in".**
2. **Reveal-on-scroll top bar** — the navbar is hidden at the top of the page and slides in once the user starts scrolling.
3. **Minimal menu** — keep only the logo + Wopee.io title + **Pricing**. Remove the **Solutions** dropdown and the **Blog** link. (The Log in / Start for free CTAs are kept.)

## Notes

- The reveal-on-scroll is the behaviour that was removed in #233 — but only because the full-screen hero it was designed for had been reverted. #235 restored that hero, so it pairs correctly again. Scoped to the homepage (`body.is-home`), same as the original #229 implementation: the scroll listener in `index.tsx` toggles `.navbar--revealed`, with the fixed/translate rules in `custom.css`. Subpages are unaffected (navbar always visible there).

## Testing

Verified locally at 1440×900:
- At scroll 0 the navbar is hidden (`translateY(-100%)`, no `navbar--revealed`).
- After scrolling it slides in showing **Wopee.io · Pricing** (left) and **Log in · Start for free** (right).
