### PR TITLE
fix(header): keep the top menu bar always visible (sticky) on wopee.io (#4239)

### DIFF
--- a/src/components/home-page/HomeHeroVibe.tsx
+++ b/src/components/home-page/HomeHeroVibe.tsx
@@ -136,7 +136,7 @@ const HomeHeroVibe = () => {
     : AppType.E_COMMERCE;
 
   return (
-    <div className="relative min-h-screen flex flex-col justify-center items-center gap-6 sm:gap-8 lg:gap-12 overflow-hidden py-8 sm:py-10 lg:py-14">
+    <div className="relative min-h-[calc(100vh-5rem)] flex flex-col justify-center items-center gap-6 sm:gap-8 lg:gap-12 overflow-hidden py-8 sm:py-10 lg:py-14">
       <div
         className="pointer-events-none select-none absolute inset-0 w-full h-full bg-gradient-to-br from-blue-50 via-purple-50 to-indigo-100 dark:from-gray-900 dark:via-purple-900/20 dark:to-indigo-900/20 z-0"
         style={{

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -264,20 +264,6 @@ a.navbar__item:hover {
   filter: invert(1);
 }
 
-/* Homepage: navbar hidden at top, slides in on scroll (toggled in index.tsx). */
-body.is-home .navbar {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  transform: translateY(-100%);
-  transition: transform 0.3s ease;
-  will-change: transform;
-}
-body.is-home .navbar.navbar--revealed {
-  transform: translateY(0);
-}
-
 /* Hero primary CTA — slow pulsing glow when enabled, invites the click
    without ever animating loud enough to feel pushy. Disabled state stays
    still. Pulse colour matches the button fill in each theme. */

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 
 import Layout from "@theme/Layout";
 import Head from "@docusaurus/Head";
@@ -60,27 +60,12 @@ const JSONLD_APP = {
 };
 
 export default function Home(): JSX.Element {
-  // Homepage navbar reveals on scroll; styles in custom.css.
-  useEffect(() => {
-    const navbar = document.querySelector(".navbar");
-    if (!navbar) return;
-    const sync = () =>
-      navbar.classList.toggle("navbar--revealed", window.scrollY > 8);
-    sync();
-    window.addEventListener("scroll", sync, { passive: true });
-    return () => {
-      window.removeEventListener("scroll", sync);
-      navbar.classList.remove("navbar--revealed");
-    };
-  }, []);
-
   return (
     <Layout
       title="AI Testing Agents for Web Apps"
       description="Paste a URL — Wopee.io AI agents explore your web app, generate Playwright tests, run them across browsers, and self-heal when the UI changes. Start free."
     >
       <Head>
-        <body className="is-home" />
         <script type="application/ld+json">{JSON.stringify(JSONLD_ORG)}</script>
         <script type="application/ld+json">{JSON.stringify(JSONLD_APP)}</script>
       </Head>


### PR DESCRIPTION
Closes autonomous-testing/backlog#4239.

## What

Keep the top menu bar always visible while scrolling on **all** wopee.io pages.

Every page except the homepage already used the standard sticky navbar (`navbar--fixed-top` → `position: sticky; top: 0`). The homepage was the only exception: it hid the navbar at the top of the page and slid it in on scroll (`body.is-home` → `position: fixed` + a reveal-on-scroll effect, added in #236). This unifies the homepage with the rest of the site.

## Changes

- **`src/css/custom.css`** — remove the homepage-only `body.is-home .navbar` override (fixed + `translateY(-100%)` hide + `navbar--revealed`). The homepage now uses the default opaque sticky navbar like every other page.
- **`src/pages/index.tsx`** — remove the reveal-on-scroll `useEffect` and the `is-home` body class (both existed only to drive that override).
- **`src/components/home-page/HomeHeroVibe.tsx`** — size the hero to `min-h-[calc(100vh-5rem)]` so it stays exactly one screen under the now in-flow 80px navbar (no extra scroll).

## Acceptance criteria

- [x] Menu bar visible at any scroll position on all pages (desktop + mobile) — homepage now matches the already-sticky rest of the site.
- [x] No content overlap / bleed-through — opaque navbar, content flows below; anchor jump-links already offset via `section { scroll-margin-top: 80px }`.
- [x] No layout shift on load — sticky navbar is in the SSR HTML from first paint; removed the client-side reveal JS that could flash.

## Verification

`yarn build` passes. Verified via screenshots of the local production build (`yarn serve`) at the top and scrolled, desktop (1280px) and mobile (390px): navbar stays visible with no overlap in all cases.